### PR TITLE
Store extra data in blacklists

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,13 @@ Recommendations may be sparce outside the recommended range.
 
 ---
 
-To blacklist tracks or artists, pass the `-b` argument followed by an arbitrary number of whitespace separated Spotify URIs
+To blacklist tracks or artists, pass the `-b` option followed by an arbitrary number of whitespace separated Spotify URIs
 ```
 $ spotirec -b spotify:track:id spotify:track:id spotify:artist:id
+```
+To see your current blacklist entries, pass the `list` argument to the `-b` option
+```
+$ spotirec -b list
 ```
 
 ## Troubleshooting

--- a/spotirec.py
+++ b/spotirec.py
@@ -34,6 +34,7 @@ parser.add_argument('-ac', action='store_true', help='base recommendations on cu
 parser.add_argument('-tc', action='store_true', help='base recommendations on custom top tracks')
 parser.add_argument('-gc', action='store_true', help='base recommendations on custom seed genres')
 parser.add_argument('-b', metavar='uri', nargs='+', type=str, help='blacklist track or artist uri(s)')
+parser.add_argument('-b list', action='store_true', help='print blacklist entries')
 parser.add_argument('--tune', metavar='attr', nargs='+', type=str, help='specify tunable attribute(s)')
 
 if not os.path.exists(blacklist_path):
@@ -277,13 +278,32 @@ def add_to_blacklist(entries: list):
                       f'not been added to the blacklist')
     with open(blacklist_path, 'w+') as file:
         file.write(json.dumps(data))
-    exit(1)
+
+
+def print_blacklist():
+    with open(blacklist_path, 'r') as file:
+        try:
+            blacklist = json.loads(file.read())
+            print('Tracks')
+            print('--------------------------')
+            for x in blacklist['tracks']:
+                print(f'{x["name"]} by {", ".join(x["artists"]).strip(", ")} - {x["uri"]}')
+            print('\nArtists')
+            print('--------------------------')
+            for x in blacklist['artists']:
+                print(f'{x["name"]} - {x["uri"]}')
+        except json.decoder.JSONDecodeError:
+            print('Blacklist is empty')
 
 
 def parse():
     args = parser.parse_args()
     if args.b:
-        add_to_blacklist(args.b)
+        if args.b[0] == 'list':
+            print_blacklist()
+        else:
+            add_to_blacklist(args.b)
+        exit(1)
 
     if args.a:
         print('Basing recommendations off your top 5 artists')

--- a/spotirec.py
+++ b/spotirec.py
@@ -260,7 +260,8 @@ def add_to_blacklist(entries: list):
                 data['tracks'].append({'name': track['name'],
                                        'uri': uri,
                                        'artists': artists})
-                print(f'Added track \"{track["name"]}\" by {artists} to your blacklist')
+                print(f'Added track \"{track["name"]}\" by {", ".join(str(x) for x in artists).strip(", ")}'
+                      f' to your blacklist')
             elif 'artist' in uri:
                 artist = request_data(uri, 'artists')
                 data['artists'].append({'name': artist['name'],

--- a/spotirec.py
+++ b/spotirec.py
@@ -168,11 +168,12 @@ def filter_recommendations(data: json) -> list:
     with open(blacklist_path, 'r+') as file:
         try:
             blacklist = json.loads(file.read())
+            blacklist_artists = [x['uri'] for x in blacklist['artists']]
+            blacklist_tracks = [x['uri'] for x in blacklist['tracks']]
             for x in data['tracks']:
-                artists = [y for y in x['artists'] if y['uri'] in blacklist['artists']]
-                if len(artists) > 0:
+                if x['uri'] in blacklist_artists:
                     continue
-                elif x['uri'] in blacklist['tracks']:
+                elif x['uri'] in blacklist_tracks:
                     continue
                 else:
                     tracks.append(x['uri'])
@@ -247,6 +248,10 @@ def request_data(uri: str, data_type: str) -> json:
 
 
 def add_to_blacklist(entries: list):
+    """
+    Add input uris to blacklist and exit
+    :param entries: list of input uris
+    """
     with open(blacklist_path, 'r') as file:
         try:
             data = json.loads(file.read())

--- a/spotirec.py
+++ b/spotirec.py
@@ -281,6 +281,9 @@ def add_to_blacklist(entries: list):
 
 
 def print_blacklist():
+    """
+    Format and print blacklist entries
+    """
     with open(blacklist_path, 'r') as file:
         try:
             blacklist = json.loads(file.read())


### PR DESCRIPTION
Instead of just storing Spotify uri in blacklist, tracks now contain name, a list of artists, and uri, and artists contain name and uri. Additionally, I added an option argument `list` to `-b` that prints blacklist entries. Resolves #13  