### PR TITLE
Add custom top genres option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,23 @@ $ spotirec -a
 $ spotirec -tc
 $ spotirec -ac
 $ spotirec -gc
+$ spotirec -gcs
 ```
 where
-- `-t` is based off your most played tracks,
-- `-a` is based off your most played artists,
+- `-t` is based off your 5 most played tracks,
+- `-a` is based off your 5 most played artists,
 - `-tc` you can define 1-5 of your most played tracks,
 - `-ac` you can define 1-5 of your most played artists,
-- `-gc` you can define 1-5 genre seeds
+- `-gc` you can define 1-5 of your most played genre,
+- `-gcs` you can define 1-5 preset genre seeds
 
-By default, the script will base recommendations off of your top genres extracted from your top artists. For this method, pass none of the above 5 arguments.
+By default, the script will base recommendations off of your top genres extracted from your top artists. For this method, pass none of the above 6 arguments.
 
 You can also specify tunable attributes with the `--tune` option, followed by any number of whitespace separated arguments on the form `prefix_attribute=value`
 ```
 $ spotirec --tune prefix_attribute=value prefix_attribute=value
 ```
-If you wish to specify a limit, this should appear before `--tune`
+
 ### Prefixes
 
 | Prefix | Function |

--- a/spotirec.py
+++ b/spotirec.py
@@ -39,7 +39,8 @@ mutex_group.add_argument('-a', action='store_true', help='base recommendations o
 mutex_group.add_argument('-t', action='store_true', help='base recommendations on your top tracks')
 mutex_group.add_argument('-ac', action='store_true', help='base recommendations on custom top artists')
 mutex_group.add_argument('-tc', action='store_true', help='base recommendations on custom top tracks')
-mutex_group.add_argument('-gc', action='store_true', help='base recommendations on custom seed genres')
+mutex_group.add_argument('-gc', action='store_true', help='base recommendations on custom top genres')
+mutex_group.add_argument('-gcs', action='store_true', help='base recommendations on custom seed genres')
 
 parser.add_argument('--tune', metavar='attr', nargs='+', type=str, help='specify tunable attribute(s)')
 
@@ -428,7 +429,7 @@ def parse():
         rec.based_on = 'top tracks'
         rec.seed_type = 'tracks'
         add_top_seed_info(get_top_list('tracks', 5))
-    elif args.gc:
+    elif args.gcs:
         response = requests.get(f'{url_base}/recommendations/available-genre-seeds', headers=headers)
         data = json.loads(response.content.decode('utf-8'))
         rec.based_on = 'custom genres'
@@ -443,6 +444,9 @@ def parse():
         rec.based_on = 'custom tracks'
         rec.seed_type = 'tracks'
         add_custom_seed_info(data)
+    elif args.gc:
+        sort = sorted(get_user_top_genres().items(), key=lambda kv: kv[1], reverse=True)
+        print_choices([sort[x][0] for x in range(0, len(sort))])
     else:
         print('Basing recommendations off your top 5 genres')
         add_top_genres_seed()

--- a/spotirec.py
+++ b/spotirec.py
@@ -178,10 +178,10 @@ def get_top_list(list_type: str, top_limit: int) -> json:
     return json.loads(response.content.decode('utf-8'))
 
 
-def add_top_genres_seed():
+def get_user_top_genres() -> dict:
     """
-    Extract genres from user's top 50 artists and sort them from high to low.
-    Add top 5 genres to recommendation object seed info.
+    Extract genres from user's top 50 artists and map them to their amount of occurrences
+    :return: dict of genres and their count of occurrences
     """
     data = get_top_list('artists', 50)
     genres = {}
@@ -191,6 +191,14 @@ def add_top_genres_seed():
                 genres[genre] += 1
             else:
                 genres[genre] = 1
+    return genres
+
+
+def add_top_genres_seed():
+    """
+    Add top 5 genres to recommendation object seed info.
+    """
+    genres = get_user_top_genres()
     sort = sorted(genres.items(), key=lambda kv: kv[1], reverse=True)
     for x in range(0, 5):
         rec.add_seed_info(data_string=sort[x][0])


### PR DESCRIPTION
Created an option that allows the user to select 5 of their most played genres. Genres are listed from most to least, as with `-tc` and `-ac`. This option has taken the `-gc` option name, and the custom genre seeds has been renamed to `-gcs`.

Resolves #6 