### PR TITLE
Add option for custom seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,23 @@ $ spotirec -a
 $ spotirec -tc
 $ spotirec -ac
 $ spotirec -gc
+$ spotirec -gcs
 ```
 where
-- `-t` is based off your most played tracks,
-- `-a` is based off your most played artists,
+- `-t` is based off your 5 most played tracks,
+- `-a` is based off your 5 most played artists,
 - `-tc` you can define 1-5 of your most played tracks,
 - `-ac` you can define 1-5 of your most played artists,
-- `-gc` you can define 1-5 genre seeds
+- `-gc` you can define 1-5 of your most played genre,
+- `-gcs` you can define 1-5 preset genre seeds
 
-By default, the script will base recommendations off of your top genres extracted from your top artists. For this method, pass none of the above 5 arguments.
+By default, the script will base recommendations off of your top genres extracted from your top artists. For this method, pass none of the above 6 arguments.
 
 You can also specify tunable attributes with the `--tune` option, followed by any number of whitespace separated arguments on the form `prefix_attribute=value`
 ```
 $ spotirec --tune prefix_attribute=value prefix_attribute=value
 ```
-If you wish to specify a limit, this should appear before `--tune`
+
 ### Prefixes
 
 | Prefix | Function |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ $ spotirec -tc
 $ spotirec -ac
 $ spotirec -gc
 $ spotirec -gcs
+$ spotirec -c
 ```
 where
 - `-t` is based off your 5 most played tracks,
@@ -67,9 +68,10 @@ where
 - `-tc` you can define 1-5 of your most played tracks,
 - `-ac` you can define 1-5 of your most played artists,
 - `-gc` you can define 1-5 of your most played genre,
-- `-gcs` you can define 1-5 preset genre seeds
+- `-gcs` you can define 1-5 preset genre seeds,
+- `-c` you can manually input 1-5 genres, artist uris, or track uris
 
-By default, the script will base recommendations off of your top genres extracted from your top artists. For this method, pass none of the above 6 arguments.
+By default, the script will base recommendations off of your top genres extracted from your top artists. For this method, pass none of the above 7 arguments.
 
 You can also specify tunable attributes with the `--tune` option, followed by any number of whitespace separated arguments on the form `prefix_attribute=value`
 ```

--- a/spotirec.py
+++ b/spotirec.py
@@ -429,11 +429,22 @@ def print_blacklist():
 
 
 def print_user_genres_sorted(prompt=True):
+    """
+    Print user top genres to terminal in a formatted list.
+    :param prompt: whether or not user should be prompted for input
+    """
     sort = sorted(get_user_top_genres().items(), key=lambda kv: kv[1], reverse=True)
     print_choices([sort[x][0] for x in range(0, len(sort))], prompt=prompt)
 
 
 def parse_custom_input(user_input: str):
+    """
+    Parse custom input from user.
+    TODO: figure out how to handle genres so the else clause can be an error message
+    -> regex(limited) / keep list of user genres and compare(better, but leaves out other genres)
+    -> compare to user genres and genre seeds
+    :param user_input: input string
+    """
     for x in shlex.split(user_input):
         if 'track' in x:
             rec.add_seed_info(data_dict=request_data(x, 'tracks'))

--- a/spotirec.py
+++ b/spotirec.py
@@ -39,7 +39,8 @@ mutex_group.add_argument('-a', action='store_true', help='base recommendations o
 mutex_group.add_argument('-t', action='store_true', help='base recommendations on your top tracks')
 mutex_group.add_argument('-ac', action='store_true', help='base recommendations on custom top artists')
 mutex_group.add_argument('-tc', action='store_true', help='base recommendations on custom top tracks')
-mutex_group.add_argument('-gc', action='store_true', help='base recommendations on custom seed genres')
+mutex_group.add_argument('-gc', action='store_true', help='base recommendations on custom top genres')
+mutex_group.add_argument('-gcs', action='store_true', help='base recommendations on custom seed genres')
 
 parser.add_argument('--tune', metavar='attr', nargs='+', type=str, help='specify tunable attribute(s)')
 
@@ -428,7 +429,7 @@ def parse():
         rec.based_on = 'top tracks'
         rec.seed_type = 'tracks'
         add_top_seed_info(get_top_list('tracks', 5))
-    elif args.gc:
+    elif args.gcs:
         response = requests.get(f'{url_base}/recommendations/available-genre-seeds', headers=headers)
         data = json.loads(response.content.decode('utf-8'))
         rec.based_on = 'custom genres'
@@ -443,6 +444,9 @@ def parse():
         rec.based_on = 'custom tracks'
         rec.seed_type = 'tracks'
         add_custom_seed_info(data)
+    elif args.gc:
+        sort = sorted(get_user_top_genres().items(), key=lambda kv: kv[1], reverse=True)
+        print_choices([sort[x][0] for x in range(0, len(sort))])
     else:
         print('Basing recommendations off your top 5 genres')
         add_top_genres_seed()

--- a/spotirec.py
+++ b/spotirec.py
@@ -178,10 +178,10 @@ def get_top_list(list_type: str, top_limit: int) -> json:
     return json.loads(response.content.decode('utf-8'))
 
 
-def add_top_genres_seed():
+def get_user_top_genres() -> dict:
     """
-    Extract genres from user's top 50 artists and sort them from high to low.
-    Add top 5 genres to recommendation object seed info.
+    Extract genres from user's top 50 artists and map them to their amount of occurrences
+    :return: dict of genres and their count of occurrences
     """
     data = get_top_list('artists', 50)
     genres = {}
@@ -191,6 +191,14 @@ def add_top_genres_seed():
                 genres[genre] += 1
             else:
                 genres[genre] = 1
+    return genres
+
+
+def add_top_genres_seed():
+    """
+    Add top 5 genres to recommendation object seed info.
+    """
+    genres = get_user_top_genres()
     sort = sorted(genres.items(), key=lambda kv: kv[1], reverse=True)
     for x in range(0, 5):
         rec.add_seed_info(data_string=sort[x][0])

--- a/spotirec.py
+++ b/spotirec.py
@@ -75,20 +75,10 @@ class Recommendation:
         :return: description string
         """
         desc = f'Created by Spotirec - {self.created_at} - based on {self.based_on} - seed: '
-        if 'tracks' in self.seed_type:
-            seeds = ' | '.join(str(f'{x["name"]} - {", ".join(str(y) for y in x["artists"])}')
-                               for x in self.seed_info.values())
-            return f'{desc}{seeds}'
-        elif 'custom' in self.seed_type:
-            for x in self.seed_info.values():
-                if x['type'] == 'track':
-                    desc = f'{desc}{x["name"]} - {", ".join(str(y) for y in x["artists"])} | '
-                else:
-                    desc = f'{desc}{x["name"]} | '
-            return desc.strip(' | ')
-        else:
-            seeds = ' | '.join(str(x["name"]) for x in self.seed_info.values())
-            return f'{desc}{seeds}'
+        seeds = ' | '.join(
+            f'{str(x["name"])}{" - " + ", ".join(str(y) for y in x["artists"]) if x["type"] == "track" else ""}' for x
+            in self.seed_info.values())
+        return f'{desc}{seeds}'
 
     def update_limit(self, limit: int):
         """
@@ -121,9 +111,7 @@ class Recommendation:
                                                    'type': data_dict['type']}
             try:
                 assert data_dict['artists'] is not None
-                self.seed_info[len(self.seed_info)-1]['artists'] = []
-                for x in data_dict['artists']:
-                    self.seed_info[len(self.seed_info) - 1]['artists'].append(x['name'])
+                self.seed_info[len(self.seed_info)-1]['artists'] = [x['name'] for x in data_dict['artists']]
             except (KeyError, AssertionError):
                 pass
 

--- a/spotirec.py
+++ b/spotirec.py
@@ -76,8 +76,8 @@ class Recommendation:
         """
         desc = f'Created by Spotirec - {self.created_at} - based on {self.based_on} - seed: '
         seeds = ' | '.join(
-            f'{str(x["name"])}{" - " + ", ".join(str(y) for y in x["artists"]) if x["type"] == "track" else ""}' for x
-            in self.seed_info.values())
+            f'{str(x["name"])}{" - " + ", ".join(str(y) for y in x["artists"]) if x["type"] == "track" else ""}'
+            for x in self.seed_info.values())
         return f'{desc}{seeds}'
 
     def update_limit(self, limit: int):
@@ -122,9 +122,12 @@ class Recommendation:
         if 'genres' in self.seed_type:
             self.seed = ','.join(str(x['name']) for x in self.seed_info.values())
         elif 'custom' in self.seed_type:
-            self.rec_params['seed_tracks'] = ','.join(str(x['id']) for x in self.seed_info.values() if x['type'] == 'track')
-            self.rec_params['seed_artists'] = ','.join(str(x['id']) for x in self.seed_info.values() if x['type'] == 'artist')
-            self.rec_params['seed_genres'] = ','.join(str(x['name']) for x in self.seed_info.values() if x['type'] == 'genre')
+            self.rec_params['seed_tracks'] = ','.join(str(x['id']) for x in self.seed_info.values()
+                                                      if x['type'] == 'track')
+            self.rec_params['seed_artists'] = ','.join(str(x['id']) for x in self.seed_info.values()
+                                                       if x['type'] == 'artist')
+            self.rec_params['seed_genres'] = ','.join(str(x['name']) for x in self.seed_info.values()
+                                                      if x['type'] == 'genre')
             return
         else:
             self.seed = ','.join(str(x['id']) for x in self.seed_info.values())


### PR DESCRIPTION
You can now pass the `-c` option to create a playlist from a custom seed. A custom seed can be 1-5 items in any combination of `[artist uri|track uri|genre]`. Resolves #2 

Keep in mind that this PR is branched from #21 