### PR TITLE
Add autoplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Script that creates a playlist of recommendations based on the user's top artist
   - [Presets](#presets)
   - [Tuning](#tuning)
   - [Blacklists](#blacklists)
+  - [Autoplay](#autoplay)
+  - [Devices](#devices)
   - [Printing](#printing)
 - [Troubleshooting](#troubleshooting)
 
@@ -143,18 +145,45 @@ To remove entries from your blacklist, pass the `-br` option followed by an arbi
 ```
 $ spotirec -br spotify:track:id spotify:track:id spotify:artist:id
 ```
-To see your current blacklist entries, pass the `list` argument to the `-b` option
+
+### Autoplay
+You can also automatically play your new playlist upon creation using the `--play` option - here you will be prompted to select which device you want to start the playback on
 ```
-$ spotirec -b list
+$ spotirec --play
+Available devices:
+Name                   Type
+----------------------------------------
+0. Phone               Smartphone
+1. Laptop              Computer
+Please select a device by index number [default: Phone]: 1
+Would you like to save "Laptop" for later use? [y/n] y
+Enter an identifier for your device: laptop
+Saved device "Laptop" as "laptop"
+```
+You will also be asked if you want to save the device in your config for later use. If you choose to do so, you can use the `--play-device` option followed by an identifier for a device to play on a saved device
+```
+$ spotirec --play-device laptop
+```
+
+### Devices
+You can also manually save devices using the `-d` option, which provides the same functionality as `--play` without creating a playlist
+```
+$ spotirec -d
+```
+To remove a saved device, pass the `-dr` option followed by an identifier for a device
+```
+$ spotirec -dr laptop
 ```
 
 ### Printing
-You can print lists containing your available choices without having to create a playlist using the `--print` argument followed by `[artists|tracks|genres|genre-seeds]`
+You can print lists of various data contained within your Spotify account and config files using the `--print` argument followed by `[artists|tracks|genres|genre-seeds|blacklist|devices]`
 ```
 $ spotirec --print artists
 $ spotirec --print tracks
 $ spotirec --print genres
 $ spotirec --print genre-seeds
+$ spotirec --print blacklist
+$ spotirec --print devices
 ```
 
 ## Troubleshooting

--- a/api.py
+++ b/api.py
@@ -117,3 +117,27 @@ def get_genre_seeds(headers: dict) -> json:
     response = requests.get(f'{url_base}/recommendations/available-genre-seeds', headers=headers)
     error_handle('genre seeds', 200, 'GET', response=response)
     return json.loads(response.content.decode('utf-8'))
+
+
+def get_available_devices(headers: dict) -> json:
+    """
+    Retrieves user's available playback devices
+    :param headers: request headers
+    :return: devices as json object
+    """
+    response = requests.get(f'{url_base}/me/player/devices', headers=headers)
+    error_handle('playback devices', 200, 'GET', response=response)
+    return json.loads(response.content.decode('utf-8'))
+
+
+def play(device_id: str, context_uri: str, headers: dict):
+    """
+    Begin playback on user's account
+    :param device_id: id of the device to play on
+    :param context_uri: uri of what should be played
+    :param headers: request headers
+    """
+    body = {'context_uri': context_uri}
+    params = {'device_id': device_id}
+    response = requests.put(f'{url_base}/me/player/play', json=body, headers=headers, params=params)
+    error_handle('start playback', 204, 'PUT', response=response)

--- a/oauth2.py
+++ b/oauth2.py
@@ -18,7 +18,7 @@ class SpotifyOAuth:
         self.client_secret = '28147de72c3549e98b1e790f3d080b85'
         self.redirect = f'http://localhost:{self.PORT}'
         self.scopes = 'user-top-read playlist-modify-public playlist-modify-private user-read-private ' \
-                      'user-read-email ugc-image-upload'
+                      'user-read-email ugc-image-upload user-read-playback-state user-modify-playback-state'
         self.cache = f'{Path.home()}/.config/spotirec/spotirecoauth'
 
     def get_credentials(self) -> json:

--- a/recommendation.py
+++ b/recommendation.py
@@ -17,6 +17,8 @@ class Recommendation:
         self.rec_params = {'limit': str(self.limit)}
         self.playlist_name = f'Spotirec-{t.tm_mday}-{t.tm_mon}-{t.tm_year}'
         self.playlist_id = ''
+        self.auto_play = False
+        self.playback_device = {}
 
     def playlist_description(self) -> str:
         """

--- a/spotirec.py
+++ b/spotirec.py
@@ -18,8 +18,9 @@ from pathlib import Path
 
 port = 8080
 config_path = f'{Path.home()}/.config/spotirec'
-blacklist_path = f'{Path.home()}/.config/spotirec/blacklist'
-preset_path = f'{Path.home()}/.config/spotirec/presets'
+blacklist_path = f'{config_path}/blacklist'
+preset_path = f'{config_path}/presets'
+devices_path = f'{config_path}/devices'
 tune_prefix = ['max', 'min', 'target']
 tune_attr = ['acousticness', 'danceability', 'duration_ms', 'energy', 'instrumentalness', 'key', 'liveness',
              'loudness', 'mode', 'popularity', 'speechiness', 'tempo', 'time_signature', 'valence', 'popularity']
@@ -53,6 +54,9 @@ preset_mutex = rec_options_group.add_mutually_exclusive_group()
 preset_mutex.add_argument('-p', metavar='NAME', nargs=1, type=str, help='load and use preset')
 preset_mutex.add_argument('-ps', metavar='NAME', nargs=1, type=str, help='save options as preset')
 rec_options_group.add_argument('--tune', metavar='ATTR', nargs='+', type=str, help='specify tunable attribute(s)')
+play_mutex = rec_options_group.add_mutually_exclusive_group()
+play_mutex.add_argument('--play', action='store_true', help='select playback device to start playing on')
+play_mutex.add_argument('--play-device', metavar='DEVICE', nargs=1, type=str, help='start playback on device')
 
 blacklist_group = parser.add_argument_group(title='Blacklisting',
                                             description='Spotirec will exit once these actions are complete')
@@ -75,6 +79,9 @@ if not os.path.exists(blacklist_path):
     f.close()
 if not os.path.exists(preset_path):
     f = open(preset_path, 'w')
+    f.close()
+if not os.path.exists(devices_path):
+    f = open(devices_path, 'w')
     f.close()
 
 
@@ -351,7 +358,9 @@ def save_preset(name: str):
                          'seed': rec.seed,
                          'seed_type': rec.seed_type,
                          'seed_info': rec.seed_info,
-                         'rec_params': rec.rec_params}
+                         'rec_params': rec.rec_params,
+                         'auto_play': rec.auto_play,
+                         'playback_device': rec.playback_device}
     with open(preset_path, 'w+') as file:
         print(f'Saving preset \"{name}\"')
         file.write(json.dumps(preset_data))
@@ -375,10 +384,92 @@ def load_preset(name: str) -> recommendation.Recommendation:
         preset.seed_type = contents['seed_type']
         preset.seed_info = contents['seed_info']
         preset.rec_params = contents['rec_params']
+        preset.auto_play = contents['auto_play']
+        preset.playback_device = contents['playback_device']
         return preset
     except KeyError:
         print(f'Error: could not find preset \"{name}\", check spelling and try again')
         exit(1)
+
+
+def get_device(device_name: str):
+    """
+    Set playback device. Prompt from available devices if none exist.
+    Print saved devices if it does not exist.
+    :param device_name: name of playback device
+    """
+    try:
+        with open(devices_path, 'r') as file:
+            devices = json.loads(file.read())
+            try:
+                rec.playback_device = devices[device_name]
+                return
+            except KeyError:
+                print(f'Error: device \"{device_name}\" not recognized. Saved devices:')
+                for x in devices:
+                    print(x)
+                exit(1)
+    except json.decoder.JSONDecodeError:
+        print('Your device list is empty')
+        print_devices()
+
+
+def print_devices(save_prompt=True, selection_prompt=True):
+    """
+    Print available devices and prompt user to select depending on params
+    :param save_prompt: whether or not user should be prompted if they want to save
+    :param selection_prompt: whether or not user should be prompted for a selection
+    """
+    devices = api.get_available_devices(headers)['devices']
+    print('Available devices:')
+    print(f'Name{" " * 19}Type')
+    print("-" * 40)
+    for x in devices:
+        print(f'{devices.index(x)}. {x["name"]}{" " * (20 - len(x["name"]))}{x["type"]}')
+    if selection_prompt:
+        def prompt_selection() -> int:
+            try:
+                inp = int(input(f'Please select a device by index number[default: '
+                                f'{devices[0]["name"]}]: ') or 0)
+                assert devices[inp] is not None
+                return inp
+            except (IndexError, AssertionError, ValueError):
+                print('Error: please input a valid index number')
+                return prompt_selection()
+
+        selection = prompt_selection()
+        rec.playback_device = {'name': devices[selection]['name'],
+                               'id': devices[selection]['id'],
+                               'type': devices[selection]['type']}
+        save = input(f'Would you like to save \"{rec.playback_device["name"]}\" '
+                     'for later use? [y/n] ') or 'y' if save_prompt else save_device()
+        if save == 'y':
+            save_device()
+
+
+def save_device():
+    """
+    Prompt user for an identifier for device and save to config
+    """
+
+    def prompt_name() -> str:
+        try:
+            inp = input('Enter an identifier for your device: ')
+            assert inp
+            return inp
+        except AssertionError:
+            prompt_name()
+
+    name = prompt_name()
+    try:
+        with open(devices_path, 'r') as file:
+            devices = json.loads(file.read())
+    except json.decoder.JSONDecodeError:
+        devices = {}
+    devices[name] = rec.playback_device
+    with open(devices_path, 'w+') as file:
+        file.write(json.dumps(devices))
+    print(f'Saved device \"{rec.playback_device["name"]}\" as \"{name}\"')
 
 
 def filter_recommendations(data: json) -> list:
@@ -429,6 +520,8 @@ def recommend():
     api.add_to_playlist(tracks, rec.playlist_id, headers=headers)
     add_image_to_playlist(tracks)
     rec.print_selection()
+    if rec.auto_play:
+        api.play(rec.playback_device['id'], f'spotify:playlist:{rec.playlist_id}', headers)
 
 
 def parse():
@@ -444,6 +537,13 @@ def parse():
     if args.br:
         remove_from_blacklist(args.br)
         exit(1)
+
+    if args.play:
+        rec.auto_play = True
+        print_devices()
+    elif args.play_device:
+        rec.auto_play = True
+        get_device(args.play_device[0])
 
     if args.print:
         if args.print[0] == 'artists':

--- a/spotirec.py
+++ b/spotirec.py
@@ -350,6 +350,10 @@ def add_image_to_playlist(tracks: list):
 
 
 def save_preset(name: str):
+    """
+    Save recommendation object as preset
+    :param name: name of preset
+    """
     try:
         with open(preset_path, 'r') as file:
             preset_data = json.loads(file.read())
@@ -369,6 +373,11 @@ def save_preset(name: str):
 
 
 def load_preset(name: str) -> recommendation.Recommendation:
+    """
+    Load preset recommendation object from config
+    :param name: name of preset
+    :return: recommendation object with settings from preset
+    """
     print(f'Using preset \"{name}\"')
     try:
         with open(preset_path, 'r') as file:
@@ -475,6 +484,10 @@ def save_device():
 
 
 def remove_devices(devices: list):
+    """
+    Remove device(s) from user config
+    :param devices: list of devices
+    """
     try:
         with open(devices_path, 'r') as file:
             saved_devices = json.loads(file.read())
@@ -493,6 +506,9 @@ def remove_devices(devices: list):
 
 
 def print_saved_devices():
+    """
+    Print all saved devices
+    """
     try:
         with open(devices_path, 'r') as file:
             devices = json.loads(file.read())

--- a/spotirec.py
+++ b/spotirec.py
@@ -440,7 +440,7 @@ def print_devices(save_prompt=True, selection_prompt=True):
     if selection_prompt:
         def prompt_selection() -> int:
             try:
-                inp = int(input(f'Please select a device by index number[default: '
+                inp = int(input(f'Please select a device by index number [default: '
                                 f'{devices[0]["name"]}]: ') or 0)
                 assert devices[inp] is not None
                 return inp

--- a/spotirec.py
+++ b/spotirec.py
@@ -58,6 +58,9 @@ play_mutex = rec_options_group.add_mutually_exclusive_group()
 play_mutex.add_argument('--play', action='store_true', help='select playback device to start playing on')
 play_mutex.add_argument('--play-device', metavar='DEVICE', nargs=1, type=str, help='start playback on device')
 
+device_group = parser.add_argument_group(title='Playback devices')
+device_group.add_argument('-d', action='store_true', help='save a device')
+
 blacklist_group = parser.add_argument_group(title='Blacklisting',
                                             description='Spotirec will exit once these actions are complete')
 blacklist_group.add_argument('-b', metavar='URI', nargs='+', type=str, help='blacklist track(s) and/or artist(s)')
@@ -544,6 +547,9 @@ def parse():
     elif args.play_device:
         rec.auto_play = True
         get_device(args.play_device[0])
+
+    if args.d:
+        print_devices(save_prompt=False)
 
     if args.print:
         if args.print[0] == 'artists':

--- a/spotirec.py
+++ b/spotirec.py
@@ -60,6 +60,7 @@ play_mutex.add_argument('--play-device', metavar='DEVICE', nargs=1, type=str, he
 
 device_group = parser.add_argument_group(title='Playback devices')
 device_group.add_argument('-d', action='store_true', help='save a device')
+device_group.add_argument('-dr', metavar='DEVICE', nargs="+", type=str, help='remove device(s)')
 
 blacklist_group = parser.add_argument_group(title='Blacklisting')
 blacklist_group.add_argument('-b', metavar='URI', nargs='+', type=str, help='blacklist track(s) and/or artist(s)')
@@ -473,6 +474,24 @@ def save_device():
     print(f'Saved device \"{rec.playback_device["name"]}\" as \"{name}\"')
 
 
+def remove_devices(devices: list):
+    try:
+        with open(devices_path, 'r') as file:
+            saved_devices = json.loads(file.read())
+    except json.decoder.JSONDecodeError:
+        print('You have no saved devices')
+        exit(1)
+    for x in devices:
+        try:
+            del saved_devices[x]
+            print(f'Deleted device \"{x}\"')
+        except KeyError:
+            print(f'Could not find device \"{x}\" in saved devices')
+            pass
+    with open(devices_path, 'w+') as file:
+        file.write(json.dumps(saved_devices))
+
+
 def print_saved_devices():
     try:
         with open(devices_path, 'r') as file:
@@ -560,6 +579,10 @@ def parse():
 
     if args.d:
         print_devices(save_prompt=False)
+        exit(1)
+    if args.dr:
+        remove_devices(args.dr)
+        exit(1)
 
     if args.print:
         if args.print[0] == 'artists':


### PR DESCRIPTION
This turned out to be an a lot more comprehensive addition than expected. This PR adds:
- `--play` option that prompts the user to select a device, and starts playing the created playlist on said device
- `--play-device <DEVICE>` option that starts playing the created playlist on saved device `<DEVICE>`
- `-d` option that allows the user to save a device to config
- `-dr` option that allows the user to remove a saved device
- `devices` argument to `--print` option that prints all saved devices
- moved print functionality of blacklists to `--print`

Resolves #25 