### PR TITLE
Add seed sizes for non-custom schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ where
 
 By default, the script will base recommendations off of your top valid seed genres extracted from your top artists. For this method, pass none of the above 7 arguments.
 
+On all non-custom schemes, e.g.; `-a`, `-t`, and no-arg, you can specify how many seeds should be included in the recommendation. The value must be in the range 1-5, and the default value is 5
+```
+$ spotirec 3
+$ spotirec -a 2
+$ spotirec -t 4
+```
+Note that if this option is used with no-arg, it **must** be the very first argument
+
 ### Limits
 You can add a limit as an integer value with the `-l` argument
 ```

--- a/spotirec.py
+++ b/spotirec.py
@@ -39,9 +39,9 @@ parser.add_argument('n', nargs='?', type=int, const=5, help='amount of seeds to 
 # Create mutually exclusive group for recommendation types to ensure only one is given
 rec_scheme_group = parser.add_argument_group(title='Recommendation schemes')
 mutex_group = rec_scheme_group.add_mutually_exclusive_group()
-mutex_group.add_argument('-a', metavar='SEED_SIZE', nargs='?', type=int, const=5,
+mutex_group.add_argument('-a', metavar='SEED_SIZE', nargs='?', type=int, const=5, choices=range(1, 6),
                          help='base recommendations on your top artists')
-mutex_group.add_argument('-t', metavar='SEED_SIZE', nargs='?', type=int, const=5,
+mutex_group.add_argument('-t', metavar='SEED_SIZE', nargs='?', type=int, const=5, choices=range(1, 6),
                          help='base recommendations on your top tracks')
 mutex_group.add_argument('-ac', action='store_true', help='base recommendations on custom top artists')
 mutex_group.add_argument('-tc', action='store_true', help='base recommendations on custom top tracks')

--- a/spotirec.py
+++ b/spotirec.py
@@ -176,7 +176,7 @@ def print_choices(data=None, prompt=True, sort=False) -> str:
     print(line.strip('\n'))
     if prompt:
         input_string = input('Enter integer identifiers for 1-5 whitespace separated selections that you wish to '
-                             'include:\n')
+                             'include [default: top 5]:\n') or '0 1 2 3 4'
         if 'genres' in rec.seed_type:
             parse_seed_info([data[int(x)] for x in input_string.split(' ')])
         else:
@@ -216,6 +216,9 @@ def parse_seed_info(seeds):
     Adds seed data to recommendation object
     :param seeds: seed data as a string or a list
     """
+    if len(shlex.split(seeds) if type(seeds) is str else seeds) > 5:
+        print('Please enter at most 5 seeds')
+        exit(1)
     for x in shlex.split(seeds) if type(seeds) is str else seeds:
         if rec.seed_type == 'genres':
             rec.add_seed_info(data_string=x)

--- a/spotirec.py
+++ b/spotirec.py
@@ -497,6 +497,9 @@ def parse():
         print_choices(data=get_user_top_genres(), prompt=False, sort=True)
         user_input = input('Enter a combination of 1-5 whitespace separated genre names, track uris, and artist uris. '
                            '\nGenres with several words should be connected with dashes, e.g.; vapor-death-pop.\n')
+        if not user_input:
+            print('Please enter 1-5 seeds')
+            exit(1)
         parse_seed_info(user_input)
     else:
         print(f'Basing recommendations off your top {args.n} genres')


### PR DESCRIPTION
You can now specify seed size for non custom schemes. For `-a` and `-t` you simply give an integer in the range 1-5 as an argument. For no-arg you can pass the same, however it **must** be the very first argument. Resolves #7 

Also implemented some error handling with regards to input on custom schemes. For `-ac`, `-tc`, `-gc`, and `-gcs` top five are used as a default value. `-c` checks if input is present before parsing. On all schemes, size of seed list is checked, and will print an error message if it is larger than 5. Fixes one point in #9 