### PR TITLE
Add tuning option to print

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ mkdir -p /usr/bin
 mkdir -p $HOME/.config/spotirec
 
 install spotirec.py oauth2.py recommendation.py api.py -t /usr/lib/spotirec
+install tuning-opts -t $HOME/.config/spotirec
 
 ln -s /usr/lib/spotirec/spotirec.py /usr/bin/spotirec
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yay -S spotirec-git
 ```
 
 #### Manual
-On any other distribution you need to install Spotirec manually. Spotirec has two dependencies
+On any other distribution you need to install Spotirec manually. Spotirec has three dependencies
 ```
 bottle>=0.12.17
 requests>=2.22.0
@@ -146,11 +146,11 @@ $ spotirec --tune prefix_attribute=value prefix_attribute=value
 | instrumentalness | float | 0.0-1.0 | 0.0-1.0 | Whether or not a track contains vocals. Low contains vocals, high is purely instrumental. |
 | liveness | float | 0.0-1.0 | 0.0-0.4 | Predicts whether or not a track is live. High value is live. |
 | loudness | float | -60-0 | -20-0 | Overall loudness of the track, measured in decibels. |
-| speechiness | float | 0.0-1.0 | 0.0-0.3 | Presence of spoken words. Low is a song, and high is likely to be a talk show or podcast. |
-| valence | float | 0.0-1.0 | Any | Positivity of the track. High value is positive, and low value is negative. |
+| speechiness | float | 0.0-1.0 | 0.0-0.3 | Presence of spoken words. Low is a song, high is likely to be a talk show or podcast. |
+| valence | float | 0.0-1.0 | Any | Positivity of the track. High value is positive, low value is negative. |
 | tempo | float | 0.0-220.0 | 60.0-210.0 | Overall estimated beats per minute of the track. |
 
-Recommendations may be sparce outside the recommended range.
+Recommendations may be scarce outside the recommended range.
 
 ### Blacklists
 To blacklist tracks or artists, pass the `-b` option followed by an arbitrary number of whitespace separated Spotify URIs

--- a/spotirec.py
+++ b/spotirec.py
@@ -80,7 +80,7 @@ blacklist_group.add_argument('-bc', metavar='artist|track', nargs=1, choices=['a
 
 print_group = parser.add_argument_group(title='Printing')
 print_group.add_argument('--print', metavar='TYPE', nargs=1, type=str,
-                         choices=['artists', 'tracks', 'genres', 'genre-seeds', 'devices', 'blacklist'],
+                         choices=['artists', 'tracks', 'genres', 'genre-seeds', 'devices', 'blacklist', 'tuning'],
                          help='print a list of genre seeds, or your top artists, tracks, or genres, where'
                               'TYPE=[artists|tracks|genres|genre-seeds|devices|blacklist]')
 
@@ -581,6 +581,25 @@ def filter_recommendations(data: json) -> list:
     return tracks
 
 
+def print_tuning_options():
+    try:
+        with open(f'{Path.home()}/.config/spotirec/tuning-opts', 'r') as file:
+            tuning_opts = file.readlines()
+    except FileNotFoundError:
+        print('Error: could not find tuning options file.')
+        exit(1)
+    if len(tuning_opts) == 0:
+        print('Error: tuning options file is empty.')
+        exit(1)
+    for x in tuning_opts:
+        if tuning_opts.index(x) == 0:
+            print('\033[1m' + x.strip('\n') + '\033[0m')
+        else:
+            print(x.strip('\n'))
+    print('Note that recommendations may be scarce outside the recommended ranges. If the recommended range is not '
+          'available, they may only be scarce at extreme values.')
+
+
 def recommend():
     """
     Main function for recommendations. Retrieves recommendations and tops up list if any tracks
@@ -666,6 +685,8 @@ def parse():
             print_blacklist()
         elif args.print[0] == 'devices':
             print_saved_devices()
+        elif args.print[0] == 'tuning':
+            print_tuning_options()
         exit(1)
 
     if args.a:

--- a/tuning-opts
+++ b/tuning-opts
@@ -1,0 +1,15 @@
+Attribute           Data type   Range   Recommended range   Function
+duration_ms         int         R+      N/A                 The duration of the track in milliseconds
+key                 int         0-11    N/A                 Pitch class of the track
+mode                int         0-1     N/A                 Modality of the track. 1 is major, 0 is minor
+time_signature      int         N/A     N/A                 Estimated overall time signature of the track
+popularity          int         0-100   0-100               Popularity of the track. High is popular, low is barely known
+acousticness        float        0-1     0-1                 Confidence measure for whether or not the track is acoustic. High value is acoustic
+danceability        float        0-1     0.1-0.9             How well fit a track is for dancing. Measurement includes among others tempo, rhythm stability, and beat strength. High value is suitable for dancing
+energy              float        0-1     0-1                 Perceptual measure of intensity and activity. High energy is fast, loud, and noisy, and low is slow and mellow
+instrumentalness    float        0-1     0-1                 Whether or not a track contains vocals. Low contains vocals, high is purely instrumental
+liveness            float        0-1     0-0.4               Predicts whether or not a track is live. High value is live
+loudness            float        -60-0   -20-0               Overall loudness of the track, measured in decibels
+speechiness         float        0-1     0-0.3               Presence of spoken words. Low is a song, and high is likely to be a talk show or podcast
+valence             float        0-1     0-1                 Positivity of the track. High value is positive, low value is negative
+tempo               float        0-220   60-210              Overall estimated beats per minute of the track


### PR DESCRIPTION
Resolves #57 

Note that `tuning-opts` file should be added to install script for AUR and should be put into `$HOME/.config/spotirec/`.