### PR TITLE
Rework config and save to playlist arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 # Spotirec
-Script that creates a playlist of recommendations based on the user's top artists or tracks, or genres extracted from top artists. A sort of Discover Weekly on demand.
+A CLI that can creates a playlist of recommendations based on the user's top artists or tracks, or genres extracted from top artists with various parameters - a sort of Discover Weekly on demand. Also includes functionality for various other Spotify-related actions, such as saving the currently playing track.
 
 ## Table of Contents
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 # Spotirec
-A CLI that can creates a playlist of recommendations based on the user's top artists or tracks, or genres extracted from top artists with various parameters - a sort of Discover Weekly on demand. Also includes functionality for various other Spotify-related actions, such as saving the currently playing track.
+A tool that can create a playlist of recommendations based on the user's top artists or tracks, or genres extracted from top artists with various parameters - a sort of Discover Weekly on demand. Also includes functionality for various other Spotify-related actions, such as saving the currently playing track.
 
 ## Table of Contents
 - [Installation](#installation)

--- a/api.py
+++ b/api.py
@@ -198,3 +198,9 @@ def get_playlist(headers: dict, playlist_id: str):
     response = requests.get(f'{url_base}/playlists/{playlist_id}', headers=headers)
     error_handle('retrieve playlist', 200, 'GET', response=response)
     return json.loads(response.content.decode('utf-8'))
+
+
+def remove_from_playlist(tracks: list, playlist_id: str, headers: dict):
+    data = {'tracks': [{'uri': x} for x in tracks]}
+    response = requests.delete(f'{url_base}/playlists/{playlist_id}/tracks', headers=headers, json=data)
+    error_handle('delete track from playlist', 200, 'DELETE', response=response)

--- a/api.py
+++ b/api.py
@@ -187,3 +187,14 @@ def unlike_track(headers: dict):
     response = requests.delete(f'{url_base}/me/tracks', headers=headers, params=track)
     error_handle('remove liked track', 200, 'DELETE', response=response)
 
+
+def get_playlist(headers: dict, playlist_id: str):
+    """
+    Retrieve playlist from API
+    :param headers: request headers
+    :param playlist_id: ID of the playlist
+    :return: playlist object
+    """
+    response = requests.get(f'{url_base}/playlists/{playlist_id}', headers=headers)
+    error_handle('retrieve playlist', 200, 'GET', response=response)
+    return json.loads(response.content.decode('utf-8'))

--- a/api.py
+++ b/api.py
@@ -201,6 +201,12 @@ def get_playlist(headers: dict, playlist_id: str):
 
 
 def remove_from_playlist(tracks: list, playlist_id: str, headers: dict):
+    """
+    Remove track(s) from a playlist
+    :param tracks: the tracks to remove
+    :param playlist_id: identifier of the playlist to remove tracks from
+    :param headers: request headers
+    """
     data = {'tracks': [{'uri': x} for x in tracks]}
     response = requests.delete(f'{url_base}/playlists/{playlist_id}/tracks', headers=headers, json=data)
     error_handle('delete track from playlist', 200, 'DELETE', response=response)

--- a/conf.py
+++ b/conf.py
@@ -7,11 +7,6 @@ from pathlib import Path
 
 CONFIG_DIR = f'{Path.home()}/.config/spotirec'
 URI_RE = r'spotify:(artist|track):[a-zA-Z0-9]'
-SECTION_RE = r'^\[([a-zA-Z]+)\]$'
-OPTION_RE = r'([a-z\_]*) = ([a-zA-Z0-9{}\[\]:,\"])'
-INT_RE = r'^([0-9]+)$'
-FLOAT_RE = r'^([0-9]+)\.([0-9]+)$'
-DICT_RE = r'\{.+\}'
 
 
 def open_config() -> configparser.ConfigParser:
@@ -21,6 +16,7 @@ def open_config() -> configparser.ConfigParser:
         assert len(c.keys()) > 0
         return c
     except (FileNotFoundError, AssertionError):
+        print('Config file not found, generating...')
         convert_or_create_config()
         return open_config()
 
@@ -40,6 +36,8 @@ def convert_or_create_config():
                     c.set(x, y[0], str(y[1]))
         except (FileNotFoundError, json.JSONDecodeError):
             pass
+    print('Done')
+    print('If you have the old style config files you may safely delete these, or save them as backup')
     save_config(c)
 
 

--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,160 @@
+import configparser
+import json
+from pathlib import Path
+
+
+CONFIG_DIR = f'{Path.home()}/.config/spotirec'
+
+
+def open_config() -> configparser.ConfigParser:
+    try:
+        with open(f'{CONFIG_DIR}/spotirec.conf') as f:
+            c = configparser.ConfigParser()
+            c.read_file(f)
+            return c
+    except FileNotFoundError:
+        convert_or_create_config()
+        return open_config()
+
+
+def save_config(c: configparser.ConfigParser):
+    c.write(open(f'{CONFIG_DIR}/spotirec.conf', 'w'))
+
+
+def convert_or_create_config():
+    c = configparser.ConfigParser()
+    old_conf = ['spotirecoauth', 'presets', 'blacklist', 'devices', 'playlists']
+    for x in old_conf:
+        c.add_section(x)
+        try:
+            with open(f'{CONFIG_DIR}/{x}', 'r') as f:
+                for y in json.loads(f.read()).items():
+                    c.set(x, y[0], json.dumps(y[1]) if type(y[1]) == dict else str(y[1]))
+        except FileNotFoundError:
+            pass
+    save_config(c)
+
+
+def get_oauth() -> dict:
+    c = open_config()
+    try:
+        c['spotirecoauth']
+    except KeyError:
+        c.add_section('spotirecoauth')
+        save_config(c)
+    return c['spotirecoauth']
+
+
+def get_blacklist() -> dict:
+    c = open_config()
+    try:
+        blacklist = {}
+        for x in c['blacklist'].items():
+            blacklist[x[0]] = json.loads(x[1])
+        return blacklist
+    except KeyError:
+        c.add_section('blacklist')
+        save_config(c)
+        return c['blacklist']
+
+
+def get_presets() -> dict:
+    c = open_config()
+    try:
+        presets = {}
+        for x in c['presets'].items():
+            presets[x[0]] = json.loads(x[1])
+        return presets
+    except KeyError:
+        c.add_section('presets')
+        save_config(c)
+        return c['presets']
+
+
+def save_preset(preset: dict, preset_id: str):
+    c = open_config()
+    try:
+        c['presets']
+    except KeyError:
+        c.add_section('presets')
+    c['presets'][preset_id] = json.dumps(preset)
+    print(f'Added preset {preset_id} to config')
+    save_config(c)
+
+
+def remove_preset(iden: str):
+    c = open_config()
+    try:
+        del c['presets'][iden]
+        print(f'Deleted preset {iden} from config')
+        save_config(c)
+    except KeyError:
+        print(f'Error: preset {iden} does not exist in config')
+
+
+def get_devices() -> dict:
+    c = open_config()
+    try:
+        devices = {}
+        for x in c['devices'].items():
+            devices[x[0]] = json.loads(x[1])
+        return devices
+    except KeyError:
+        c.add_section('devices')
+        save_config(c)
+        return c['devices']
+
+
+def save_device(device: dict, device_id: str):
+    c = open_config()
+    try:
+        c['devices']
+    except KeyError:
+        c.add_section('devices')
+    c['devices'][device_id] = json.dumps(device)
+    print(f'Added device {device_id} to config')
+    save_config(c)
+
+
+def remove_device(iden: str):
+    c = open_config()
+    try:
+        del c['devices'][iden]
+        print(f'Deleted device {iden} from config')
+        save_config(c)
+    except KeyError:
+        print(f'Error: device {iden} does not exist in config')
+
+
+def get_playlists() -> dict:
+    c = open_config()
+    try:
+        playlists = {}
+        for x in c['playlists'].items():
+            playlists[x[0]] = json.loads(x[1])
+        return playlists
+    except KeyError:
+        c.add_section('playlists')
+        save_config(c)
+    return c['playlists']
+
+
+def save_playlist(playlist: dict, playlist_id: str):
+    c = open_config()
+    try:
+        c['playlists']
+    except KeyError:
+        c.add_section('playlists')
+    c['playlists'][playlist_id] = json.dumps(playlist)
+    print(f'Added playlist {playlist_id} to config')
+    save_config(c)
+
+
+def remove_playlist(iden: str):
+    c = open_config()
+    try:
+        del c['playlists'][iden]
+        print(f'Deleted playlist {iden} from config')
+        save_config(c)
+    except KeyError:
+        print(f'Error: playlist {iden} does not exist in config')

--- a/oauth2.py
+++ b/oauth2.py
@@ -24,7 +24,7 @@ class SpotifyOAuth:
     def get_credentials(self) -> json:
         """
         Get credentials from cache file. Refresh token if it's about to expire.
-        :return: token contents as a json object
+        :return: token contents as a config object
         """
         try:
             creds = conf.get_oauth()
@@ -110,8 +110,8 @@ class SpotifyOAuth:
 
     def save_token(self, token: json, refresh_token=None):
         """
-        Add 'expires at' field and reapplies refresh token to token, and save to cache
-        :param token: credentials as a json object
+        Add 'expires at' field and reapplies refresh token to token, and save to config
+        :param token: credentials as a config object
         :param refresh_token: user refresh token
         """
         token['expires_at'] = round(time.time()) + int(token['expires_in'])

--- a/oauth2.py
+++ b/oauth2.py
@@ -28,6 +28,7 @@ class SpotifyOAuth:
         """
         try:
             creds = conf.get_oauth()
+            print(creds)
             if self.is_token_expired(int(creds['expires_at'])):
                 print('OAuth token is expired, refreshing...')
                 creds = self.refresh_token(creds['refresh_token'])
@@ -119,5 +120,5 @@ class SpotifyOAuth:
             token['refresh_token'] = refresh_token
         c = conf.open_config()
         for x in token.items():
-            c.set('spotirecoauth', x[0], str(x[1]))
+            c['spotirecoauth'][x[0]] = str(x[1])
         conf.save_config(c)

--- a/oauth2.py
+++ b/oauth2.py
@@ -28,12 +28,11 @@ class SpotifyOAuth:
         """
         try:
             creds = conf.get_oauth()
-            print(creds)
             if self.is_token_expired(int(creds['expires_at'])):
                 print('OAuth token is expired, refreshing...')
                 creds = self.refresh_token(creds['refresh_token'])
         except (IOError, json.decoder.JSONDecodeError):
-            print('Error: cache does not exist or is empty')
+            print('Error: OAuth config does not exist or is empty')
             return None
         return creds
 

--- a/spotirec.py
+++ b/spotirec.py
@@ -127,7 +127,7 @@ def get_token() -> str:
     """
     creds = sp_oauth.get_credentials()
     if creds:
-        return creds['access_token']
+        return creds.get('access_token')
     else:
         authorize()
         exit(1)
@@ -289,10 +289,10 @@ def print_blacklist():
     """
     blacklist = conf.get_blacklist()
     print('\033[1m' + 'Tracks' + '\033[0m')
-    for x in blacklist['tracks'].values():
+    for x in blacklist.get('tracks').values():
         print(f'{x["name"]} by {", ".join(x["artists"])} - {x["uri"]}')
     print('\n' + '\033[1m' + 'Artists' + '\033[0m')
-    for x in blacklist['artists'].values():
+    for x in blacklist.get('artists').values():
         print(f'{x["name"]} - {x["uri"]}')
 
 
@@ -355,7 +355,7 @@ def load_preset(name: str) -> recommendation.Recommendation:
     print(f'Using preset \"{name}\"')
     presets = conf.get_presets()
     try:
-        contents = presets[name]
+        contents = presets.get(name)
     except KeyError:
         print(f'Error: could not find preset \"{name}\", check spelling and try again')
         exit(1)
@@ -398,7 +398,7 @@ def get_device(device_name: str) -> dict:
     """
     devices = conf.get_devices()
     try:
-        return devices[device_name]
+        return devices.get(device_name)
     except KeyError:
         print(f'Error: device {device_name} does not exist in config')
         exit(1)
@@ -436,8 +436,9 @@ def save_device():
     for x in devices:
         print(f'{devices.index(x)}. {x["name"]}{" " * (20 - len(x["name"]))}{x["type"]}')
     device = devices[prompt_device_index()]
+    device_dict = {'id': device['id'], 'name': device['name'], 'type': device['type']}
     name = prompt_name()
-    conf.save_device(device, name)
+    conf.save_device(device_dict, name)
 
 
 def remove_devices(devices: list):
@@ -586,14 +587,13 @@ def parse():
         save_playlist()
         exit(1)
     elif args.remove_playlists:
-        print('Removing playlist from config')
-        remove_playlists(args.remove_playlist)
+        remove_playlists(args.remove_playlists)
         exit(1)
     elif args.save_device:
         save_device()
         exit(1)
     elif args.remove_devices:
-        remove_devices(args.remove_device)
+        remove_devices(args.remove_devices)
         exit(1)
     elif args.remove_presets:
         remove_presets(args.remove_presets)

--- a/spotirec.py
+++ b/spotirec.py
@@ -503,7 +503,7 @@ def remove_playlists(playlists: list):
 
 
 def add_current_track(playlist: str):
-    if re.match(URI_RE, playlist):
+    if re.match(PLAYLIST_URI_RE, playlist):
         playlist_id = playlist.split(':')[2]
     else:
         playlists = conf.get_playlists()
@@ -512,12 +512,12 @@ def add_current_track(playlist: str):
         except KeyError:
             print(f'Error: playlist {playlist} does not exist in config')
             exit(1)
-    print(f'Adding currently playing track to playlist {playlists[playlist]["name"]}')
+    print(f'Adding currently playing track to playlist')
     api.add_to_playlist([api.get_current_track(headers)], playlist_id, headers)
 
 
 def remove_current_track(playlist: str):
-    if re.match(URI_RE, playlist):
+    if re.match(PLAYLIST_URI_RE, playlist):
         playlist_id = playlist.split(':')[2]
     else:
         playlists = conf.get_playlists()
@@ -526,7 +526,7 @@ def remove_current_track(playlist: str):
         except KeyError:
             print(f'Error: playlist {playlist} does not exist in config')
             exit(1)
-    print(f'Removing currently playing track to playlist {playlists[playlist]["name"]}')
+    print(f'Removing currently playing track to playlist')
     api.remove_from_playlist([api.get_current_track(headers)], playlist_id, headers)
 
 
@@ -592,8 +592,6 @@ def parse():
         exit(1)
 
     if args.s:
-        if len(args.s) > 0:
-            exit(1)
         print('Liking current track')
         api.like_track(headers=headers)
         exit(1)
@@ -648,7 +646,7 @@ def parse():
 
     if args.play:
         rec.auto_play = True
-        rec.playback_device = get_device(args.play)
+        rec.playback_device = get_device(args.play[0])
 
     if args.a:
         print(f'Basing recommendations off your top {args.a} artist(s)')


### PR DESCRIPTION
Decided to rework the config files as well, so this PR will be a bit more comprehensive than expected.

- [x] Rework config to use one file, rather than 5 - see below
  - This is managed through `conf.py`.
- [x] Make config modifying argument names more uniform
  - Most (sans blacklist) will follow a `--[remove|save]-TYPE` scheme.
- [x] Make functions relevant to the above arguments more uniform
- [x] Added function that converts old config to new
- [x] Allow adding and removing currently playing track to specific playlist
- [x] Allow saving and removing playlists in config
- [x] Update README
- [x] Use case test on everything
  - [x] no-arg with and without n
  - [x] -a with and without seed size
  - [x] -t with and without seed size
  - [x] -ac
  - [x] -tc
  - [x] -gc
  - [x] -gcs
  - [x] -c with different type inputs
  - [x] -s
  - [x] -sr
  - [x] --add-to with saved list and uri
  - [x] --remove-from with saved list and uri
  - [x] --save/remove-playlist
  - [x] --save/remove-device
  - [x] --save/remove/load-preset
  - [x] -l with any
  - [x] --tune with any
  - [x] --play
  - [x] -b, -br, -bc
  - [x] all --print

Config structure:
```
$ cat ~/.config/spotirec/spotirec.conf
[spotirecoauth]
access_token = str
token_type = str
expires_in = int
refresh_token = str
scope = str
expires_at = int

[presets]
preset-id = dict

[blacklist]
tracks =dict
artists = dict

[devices]
device-id = dict

[playlists]
playlist-id = dict
``` 

Stuff to fix when merging the remaining PRs:
- [ ] Implement graceful keyboard interrupt handling for new input prompts
- [ ] Maybe set default playlist as a saved playlist