### PR TITLE
Notify when recommendation yields few different tracks

### DIFF
--- a/api.py
+++ b/api.py
@@ -254,3 +254,19 @@ def get_audio_features(track_id: str, headers: dict) -> json:
     response = requests.get(f'{url_base}/audio-features/{track_id}', headers=headers)
     error_handle('retrieve audio features', 200, 'GET', response=response)
     return json.loads(response.content.decode('utf-8'))
+
+
+def check_if_playlist_exists(playlist_id: str, headers: dict) -> bool:
+    """
+    Checks whether a playlist exists
+    :param playlist_id: id of playlist
+    :param headers: request headers
+    :return: bool determining if playlist exists
+    """
+    response = requests.get(f'{url_base}/playlists/{playlist_id}', headers=headers)
+    # If playlist is public, return true (if playlist has been deleted, this value is false)
+    if json.loads(response.content.decode('utf-8'))['public']:
+        return True
+    else:
+        print('Playlist has either been deleted, or made private, creating new...')
+        return False


### PR DESCRIPTION
Added a check that gives a warning when a recommendation request yields few tracks - this would result in duplicates.

Note that this is simply done by checking if the amount of tracks left over after filtering is less than half of the track limit. There may be a far better way of handling this, and I would like your input, @cogitantium.

Also fixed a few errors; removed a remnant from testing the new tuning validation - the program would exit after the first check; adding tracks to the default playlist did not take into account if the user had deleted the playlist - this has been fixed.

Resolves #72 