### PR TITLE
Check if item is in blacklist before adding

### DIFF
--- a/spotirec/conf.py
+++ b/spotirec/conf.py
@@ -106,6 +106,15 @@ class Config:
             return {'tracks': ast.literal_eval(c.get('blacklist', 'tracks')),
                     'artists': ast.literal_eval(c.get('blacklist', 'artists'))}
 
+    def check_item_in_blacklist(self, uri):
+        """
+        Checks whether or not a track or artist is blacklisted
+        :param uri: uri of track or artist
+        :return: bool: true if uri is blacklisted, false if not
+        """
+        blacklist = self.get_blacklist()
+        return uri in blacklist[f'{uri.split(":")[1]}s'].keys()
+
     def add_to_blacklist(self, uri_data: json, uri: str):
         """
         Add entry to blacklist

--- a/spotirec/conf.py
+++ b/spotirec/conf.py
@@ -112,8 +112,7 @@ class Config:
         :param uri: uri of track or artist
         :return: bool: true if uri is blacklisted, false if not
         """
-        blacklist = self.get_blacklist()
-        return uri in blacklist[f'{uri.split(":")[1]}s'].keys()
+        return uri in self.get_blacklist()[f'{uri.split(":")[1]}s'].keys()
 
     def add_to_blacklist(self, uri_data: json, uri: str):
         """

--- a/spotirec/spotirec.py
+++ b/spotirec/spotirec.py
@@ -452,8 +452,9 @@ def add_to_blacklist(entries: list):
     logger.verbose('adding blacklist entries')
     for x in entries:
         logger.debug(f'entry: {x}')
-        uri_data = api.request_data(x, f'{x.split(":")[1]}s', headers)
-        conf.add_to_blacklist(uri_data, x)
+        if not conf.check_item_in_blacklist(x):
+            uri_data = api.request_data(x, f'{x.split(":")[1]}s', headers)
+            conf.add_to_blacklist(uri_data, x)
 
 
 def remove_from_blacklist(entries: list):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -167,6 +167,24 @@ class TestConf(SpotirecTestCase):
         self.conf.remove_from_blacklist('spotify:track:thisdoesnotexist')
 
     @ordered
+    def test_check_item_in_blacklist_true(self):
+        """
+        Testing check_item_in_blacklist() (true)
+        """
+        test_artist = {'name': 'frankie', 'uri': 'spotify:artist:testuri0frankie'}
+        self.conf.add_to_blacklist(test_artist, test_artist['uri'])
+        self.assertTrue(self.conf.check_item_in_blacklist(test_artist['uri']))
+        self.conf.remove_from_blacklist(test_artist['uri'])
+
+    @ordered
+    def test_check_item_in_blacklist_false(self):
+        """
+        Testing check_item_in_blacklist() (false)
+        """
+        test_uri = 'spotify:artist:testuri0frankie'
+        self.assertFalse(self.conf.check_item_in_blacklist(test_uri))
+
+    @ordered
     def test_get_presets(self):
         """
         Testing get_presets()


### PR DESCRIPTION
Avoid unnecessary API request if item is already present in blacklist.