### PR TITLE
Concert recommender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 __pycache__
 .coverage
 htmlcov/
-venv/
+**/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .coverage
 htmlcov/
 **/.idea
+**/venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 bottle>=0.12.17
 requests>=2.22.0
 Pillow>=6.2.1
+setuptools~=58.1.0
+beautifulsoup4~=4.10.0

--- a/spotirec/api.py
+++ b/spotirec/api.py
@@ -84,6 +84,17 @@ class API:
                                     'spotirec-default')
         return playlist['id']
 
+    def get_top_tacks_from_artist(self, artist_id: str, headers) -> list:
+        response = requests.get(f'{self.URL_BASE}/artists/{artist_id}/top-tracks?market={self.get_user_country(headers)}',
+                                headers=headers)
+        self.error_handle('artist top tracks', 200, 'GET', response=response)
+        return [x['id'] for x in json.loads(response.content.decode('utf-8'))['tracks']]
+
+    def get_user_country(self, headers):
+        response = requests.get(f'{self.URL_BASE}/me', headers=headers)
+        self.error_handle('user info', 200, 'GET', response=response)
+        return json.loads(response.content.decode('utf-8'))['country']
+
     def upload_image(self, playlist_id: str, data: str, img_headers: dict):
         """
         Upload the generated image to the playlist

--- a/spotirec/api.py
+++ b/spotirec/api.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 import json
-import requests
 import sys
+import requests
+
 from . import conf as sp_conf, log
 
 
@@ -62,10 +63,11 @@ class API:
         self.error_handle('user info', 200, 'GET', response=response)
         return json.loads(response.content.decode('utf-8'))['id']
 
-    def create_playlist(self, playlist_name: str, playlist_description: str, headers: dict,
+    def create_playlist(self, playlist_name: str, playlist_description: str, headers: dict, save_name: str = None,
                         cache_id=False) -> str:
         """
         Creates playlist on user's account.
+        :param save_name: if set, the playlist will be saved locally with that name
         :param cache_id: whether playlist id should be saved as default or not
         :param playlist_name: name of the playlist
         :param playlist_description: description of the playlist
@@ -81,7 +83,7 @@ class API:
         playlist = json.loads(response.content.decode('utf-8'))
         if cache_id:
             self.CONF.save_playlist({'name': playlist['name'], 'uri': playlist['uri']},
-                                    'spotirec-default')
+                                    f'{save_name}' if save_name else 'spotirec-default')
         return playlist['id']
 
     def get_top_tacks_from_artist(self, artist_id: str, headers) -> list:

--- a/spotirec/api.py
+++ b/spotirec/api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import json
-import sys
 import requests
+import sys
 
 from . import conf as sp_conf, log
 

--- a/spotirec/main.py
+++ b/spotirec/main.py
@@ -1,12 +1,12 @@
 from . import spotirec
-from .spotirec import setup_config_dir, init, recommend
-
+from .spotirec import setup_config_dir, init, add_tracks_to_playlist
 
 def run():
     parser = spotirec.create_parser()
     spotirec.args = parser.parse_args()
     setup_config_dir()
     init()
-    recommend()
+    add_tracks_to_playlist()
+
     if spotirec.args.log:
         spotirec.logger.log_file()

--- a/spotirec/recommendation.py
+++ b/spotirec/recommendation.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import time
+
 from . import log
 
 
@@ -35,20 +36,24 @@ class Recommendation:
                     'id': self.playlist_id, 'auto play': self.auto_play,
                     'device': self.playback_device})
 
-    def playlist_description(self) -> str:
+    def playlist_description(self, concert: bool) -> str:
         """
         Create playlist description string to be insterted into playlist. Description contains
         date and time of creation, recommendation method, and seed.
         :return: description string
         """
         self.LOGGER.verbose('generating playlist description')
-        desc = f'Created by Spotirec - {self.created_at} - based on {self.based_on} - seed: '
-        seeds = ' | '.join(
-            f'{str(x["name"])}'
-            f'{" - " + ", ".join(str(y) for y in x["artists"]) if x["type"] == "track" else ""}'
-            for x in self.seed_info.values())
-        self.LOGGER.debug(f'description: {desc}{seeds}')
-        return f'{desc}{seeds}'
+        desc = f'Created by Spotirec {self.created_at} - based on {self.based_on}'
+
+        if not concert:
+            desc += f' - seed: '
+            seeds = ' | '.join(
+                f'{str(x["name"])}'
+                f'{" - " + ", ".join(str(y) for y in x["artists"]) if x["type"] == "track" else ""}'
+                for x in self.seed_info.values())
+            self.LOGGER.debug(f'description: {desc}{seeds}')
+            desc += seeds
+        return desc
 
     def update_limit(self, limit: int, init=False):
         """
@@ -93,7 +98,7 @@ class Recommendation:
                                                                       for x in data_dict['artists']]
             except KeyError:
                 pass
-            self.LOGGER.debug(f'data: {self.seed_info[len(self.seed_info)-1]}')
+            self.LOGGER.debug(f'data: {self.seed_info[len(self.seed_info) - 1]}')
 
     def create_seed(self):
         """

--- a/spotirec/recommendation.py
+++ b/spotirec/recommendation.py
@@ -13,8 +13,9 @@ class Recommendation:
     def __init__(self, t=TIME, preset=None):
         if preset is None:
             preset = {}
-        self.limit = preset.pop('limit', 100)
-        self.limit_original = preset.pop('limit', self.limit)
+        limit = preset.pop('limit', 100)
+        self.limit = limit if limit <= 100 else 100
+        self.limit_original = limit
         self.created_at = time.ctime(time.time())
         self.based_on = preset.pop('based_on', 'top genres')
         self.seed = preset.pop('seed', '')
@@ -56,7 +57,7 @@ class Recommendation:
         :param init: should only be true when updated by -l arg
         """
         self.LOGGER.verbose('updating limit')
-        self.limit = limit
+        self.limit = limit if limit <= 100 else 100
         self.rec_params['limit'] = str(self.limit)
         if init:
             self.limit_original = limit

--- a/spotirec/scrapers/Concerts.py
+++ b/spotirec/scrapers/Concerts.py
@@ -1,0 +1,43 @@
+import re
+import sys
+
+from bs4 import BeautifulSoup
+
+from spotirec.scrapers import ScraperBase
+
+
+class ConcertScraper(ScraperBase.ScraperBase):
+    """
+    Scrapes concert data from the spotify.
+    """
+    def __init__(self, url: str, logger):
+        """
+        Checks if the url is a valid spotify concert url.
+        """
+        regex = r"[0-9a-zA-Z]{22}"
+        if self.is_file:
+            logger.debug('The url is a file, process as such')
+        elif url.startswith('https://open.spotify.com/concert/') and re.match(regex + r"(/|)$", url):
+            logger.debug('Matches on a full url')
+        elif re.search('^' + regex + "$", url):
+            logger.debug('Matches on an identifier')
+            url = 'https://open.spotify.com/concert/' + url
+        else:
+            logger.error('The url you provided is not a valid spotify concert url or identifier of the concert')
+            sys.exit(1)
+        super().__init__(url, logger)
+
+    def _run(self, soup) -> tuple[dict, str]:
+        try:
+            soup: BeautifulSoup
+            concert_lineups = soup.find('section', class_='concert-section-container').find('div',
+                                                                                            class_='wrapper').find_all('a')
+            artist_ids = [concert_lineup.get('href').replace('/artist/', '') for concert_lineup in concert_lineups]
+            artists = {x.find('div', class_='concert-artist-info-name').text.strip(): artist_ids[i] for i, x in
+                       enumerate(concert_lineups)}
+            concert_name = soup.find('h1').text.strip()
+        except AttributeError:
+            self.logger.error('It don\'t seem like there is anything on that url, could you please check again?')
+            sys.exit(1)
+
+        return artists, 'the concert ' + concert_name

--- a/spotirec/scrapers/Concerts.py
+++ b/spotirec/scrapers/Concerts.py
@@ -15,9 +15,7 @@ class ConcertScraper(ScraperBase.ScraperBase):
         Checks if the url is a valid spotify concert url.
         """
         regex = r"[0-9a-zA-Z]{22}"
-        if self.is_file:
-            logger.debug('The url is a file, process as such')
-        elif url.startswith('https://open.spotify.com/concert/') and re.match(regex + r"(/|)$", url):
+        if url.startswith('https://open.spotify.com/concert/') and re.match(regex + r"(/|)$", url):
             logger.debug('Matches on a full url')
         elif re.search('^' + regex + "$", url):
             logger.debug('Matches on an identifier')

--- a/spotirec/scrapers/ScraperBase.py
+++ b/spotirec/scrapers/ScraperBase.py
@@ -1,0 +1,29 @@
+import pathlib
+from abc import ABC, abstractmethod
+
+import requests
+from bs4 import BeautifulSoup
+
+
+class ScraperBase(ABC):
+    """
+    Abstract class for scraping any page.
+    An inherited class should implement _run
+    """
+    url: str = ""
+
+    def __init__(self, url, logger, is_file=False):
+        self.url = url
+        self.logger = logger
+        self.is_file = is_file
+
+    def run(self) -> dict:
+        if self.is_file:
+            return self._run(BeautifulSoup(open(self.url), "html.parser"))
+        return self._run(BeautifulSoup(
+            requests.get(self.url).text,
+            'html.parser'))
+
+    @abstractmethod
+    def _run(self, soup: BeautifulSoup) -> dict:
+        raise NotImplemented("This should be implemented")

--- a/spotirec/scrapers/ScraperBase.py
+++ b/spotirec/scrapers/ScraperBase.py
@@ -12,14 +12,11 @@ class ScraperBase(ABC):
     """
     url: str = ""
 
-    def __init__(self, url, logger, is_file=False):
+    def __init__(self, url, logger):
         self.url = url
         self.logger = logger
-        self.is_file = is_file
 
     def run(self) -> dict:
-        if self.is_file:
-            return self._run(BeautifulSoup(open(self.url), "html.parser"))
         return self._run(BeautifulSoup(
             requests.get(self.url).text,
             'html.parser'))

--- a/spotirec/spotirec.py
+++ b/spotirec/spotirec.py
@@ -1042,8 +1042,6 @@ def add_tracks_to_playlist():
             rec.update_limit(rec.limit_original - len(tracks))
             tracks += filter_recommendations(api.get_recommendations(rec.rec_params, headers), tracks)
 
-    print(tracks)
-
     def add_tracks():
         n_requests = math.ceil(len(tracks) / 100)
         for i in range(n_requests):

--- a/spotirec/spotirec.py
+++ b/spotirec/spotirec.py
@@ -1057,7 +1057,7 @@ def add_tracks_to_playlist():
         add_tracks()
 
     # Create playlist and add tracks
-    if args.preserve:
+    if args.preserve or args.concert:
         logger.info('preserving playlist and creating new default')
         create_new_playlist()
     else:

--- a/tests/fixtures/concert.html
+++ b/tests/fixtures/concert.html
@@ -1,0 +1,7571 @@
+<html lang="en" dir="ltr" class="no-focus-outline spotify__os--is-linux spotify__container--is-web"
+      style="--nav-bar-width:232px;">
+<head>
+    <meta charset="UTF-8">
+    <title>Spotify – STARSET</title>
+    <link rel="icon" sizes="32x32" type="image/png" href="https://open.scdn.co/cdn/images/favicon32.8e66b099.png">
+    <link rel="icon" sizes="16x16" type="image/png" href="https://open.scdn.co/cdn/images/favicon16.c498a969.png">
+    <link rel="icon" href="https://open.scdn.co/cdn/images/favicon.5cb2bd30.ico">
+    <link rel="manifest" href="https://open.scdn.co/cdn/generated/manifest-web-player.562e545c.json">
+    <link rel="stylesheet" href="https://open.scdn.co/cdn/build/web-player/web-player.ad8c299f.css">
+    <link rel="stylesheet" href="https://open.scdn.co/cdn/build/web-player/vendor~web-player.ced44631.css">
+    <script async="" src="https://www.googletagmanager.com/gtm.js?id=GTM-PZHN3VD"></script>
+    <script type="text/javascript" async=""
+            src="https://www.gstatic.com/recaptcha/releases/UrRmT3mBwY326qQxUfVlHu1P/recaptcha__en.js"
+            crossorigin="anonymous"
+            integrity="sha384-b3tGrrJFQIPZurcFNV2vrA2u2er9PWPAKHNcMEptlkLhk70c4ZdB0G3jp+CLqqAB"></script>
+    <script id="config" data-testid="config" type="application/json">{
+        "clientId": "0971d",
+        "accessToken": "BQCrZ8PCjKbFPuB1S_XoYSlmCFgPVpxjQb-R9M_2SmaD4aO8ToI11YEy1Qy_Hn1lDFOyEHLABXA4JB2EM0G9MxVK_73b07iuSuf0Mlg1qc_95zZV8nT-AJWfBvgVTKbddES5zOdFId3piK6CyrQxMExrbLNsvXIHREB0C6goxIU5-nZ0p0fBEquL05B_u1Tt7F00TDAIikRcixxnLlREVn19CkKObig30bkPz04wQQVKXmM-ATaeUcz4k7lv59tTmGxI-uGliv87NFfXGAgcHAMogRDNZ4SJSTIT-0XsbJiYRyScSZzsq94Yrdsv",
+        "accessTokenExpirationTimestampMs": 1635942725191,
+        "isAnonymous": false,
+        "recaptchaWebPlayerFraudSiteKey": "6LfCVLAUAAAAALFwwRnnCJ12DalriUGbj8FW_J39",
+        "app_name": "web_player_prototype",
+        "market": "DK",
+        "locale": {
+            "locale": "en",
+            "rtl": false,
+            "textDirection": "ltr"
+        },
+        "gtmId": "GTM-PZHN3VD",
+        "optimizeId": "GTM-W53X654",
+        "userCountry": "DK",
+        "isPremium": true,
+        "correlationId": "21e432665eced9efdb913c00e7b66265",
+        "retargetingPixels": null
+    }</script>
+    <script id="baba" type="application/json">[]</script>
+    <script defer="" src="https://www.googleoptimize.com/optimize.js?id=GTM-W53X654"></script>
+    <script defer="" src="https://open.scdn.co/cdn/js/gtm.fc4d97de.js"></script>
+    <link rel="preconnect" href="https://api.spotify.com" crossorigin="anonymous">
+    <link rel="preconnect" href="https://apresolve.spotify.com" crossorigin="anonymous">
+    <link rel="preconnect" href="https://daily-mix.scdn.co" crossorigin="anonymous">
+    <link rel="preconnect" href="https://exp.wg.spotify.com" crossorigin="anonymous">
+    <link rel="preconnect" href="https://gew-dealer.spotify.com" crossorigin="anonymous">
+    <link rel="preconnect" href="https://gew-spclient.spotify.com" crossorigin="anonymous">
+    <link rel="preconnect" href="https://i.scdn.co" crossorigin="anonymous">
+    <link rel="preconnect" href="https://lineup-images.scdn.co" crossorigin="anonymous">
+    <link rel="preconnect" href="https://mosaic.scdn.co" crossorigin="anonymous">
+    <link rel="preconnect" href="https://open.scdn.co" crossorigin="anonymous">
+    <link rel="preconnect" href="https://pixel-static.spotify.com" crossorigin="anonymous">
+    <link rel="preconnect" href="https://pixel.spotify.com" crossorigin="anonymous">
+    <link rel="preconnect" href="https://pl.scdn.co" crossorigin="anonymous">
+    <link rel="preconnect" href="https://spclient.wg.spotify.com" crossorigin="anonymous">
+    <link rel="preload" href="https://open.scdn.co/cdn/fonts/CircularSpUIv3T-Book.3466e0ec.woff2" as="font"
+          type="font/woff2" crossorigin="anonymous">
+    <link rel="preload" href="https://open.scdn.co/cdn/fonts/CircularSpUIv3T-Bold.8d0a45cc.woff2" as="font"
+          type="font/woff2" crossorigin="anonymous">
+    <link rel="preload" href="https://open.scdn.co/cdn/fonts/CircularSpUIv3T-Light.afd9ab26.woff2" as="font"
+          type="font/woff2" crossorigin="anonymous">
+    <link rel="preload" href="https://open.scdn.co/cdn/fonts/spoticon_regular_2.d319d911.woff2" as="font"
+          type="font/woff2" crossorigin="anonymous">
+    <link rel="preconnect" href="https://api.spotify.com">
+    <link rel="preconnect" href="https://spclient.wg.spotify.com">
+    <link rel="preconnect" href="https://apresolve.spotify.com">
+    <style>.grecaptcha-badge {
+        display: none !important;
+    }</style>
+    <script src="https://www.google.com/recaptcha/enterprise.js?render=6LfCVLAUAAAAALFwwRnnCJ12DalriUGbj8FW_J39"
+            async="" defer=""></script>
+    <link rel="search" type="application/opensearchdescription+xml" title="Spotify"
+          href="https://open.scdn.co/cdn/generated/opensearch.7e787b90.xml">
+    <link rel="prefetch" as="script"
+          href="https://open.scdn.co/cdn/build/web-player/xpui-routes-offline-browse.866e654c.js">
+    <script src="//www.gstatic.com/cast/sdk/libs/sender/1.0/cast_framework.js"></script>
+    <script src="chrome-extension://pkedcjkdefgpdelpbcmbmeomcjbeemfm/cast_sender.js"></script>
+    <script src="chrome-extension://enhhojjnijigcajfphajepfemndkmdlo/cast_sender.js"></script>
+    <style data-styled="active" data-styled-version="5.3.1"></style>
+    <link rel="stylesheet" type="text/css"
+          href="https://open.scdn.co/cdn/build/web-player/xpui-routes-concert.93eb6c6f.css">
+    <script data-domain-script="50da44be-0564-43df-b139-329aedcf267b" data-document-language="true"
+            src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"></script>
+    <script>(function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+        var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl + window.__gtm_additional_data;
+        f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', window.__gtm_track_id);</script>
+    <script src="https://cdn.cookielaw.org/scripttemplates/6.24.0/otBannerSdk.js" async=""
+            type="text/javascript"></script>
+    <script type="text/javascript" async="" src="https://cdn.cookielaw.org/scripttemplates/6.24.0/otTCF.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style id="onetrust-style">#onetrust-banner-sdk {
+        -ms-text-size-adjust: 100%;
+        -webkit-text-size-adjust: 100%
+    }
+
+    #onetrust-banner-sdk .onetrust-vendors-list-handler {
+        cursor: pointer;
+        color: #1f96db;
+        font-size: inherit;
+        font-weight: bold;
+        text-decoration: none;
+        margin-left: 5px
+    }
+
+    #onetrust-banner-sdk .onetrust-vendors-list-handler:hover {
+        color: #1f96db
+    }
+
+    #onetrust-banner-sdk:focus {
+        outline: 2px solid #000;
+        outline-offset: -2px
+    }
+
+    #onetrust-banner-sdk a:focus {
+        outline: 2px solid #000
+    }
+
+    #onetrust-banner-sdk #onetrust-accept-btn-handler, #onetrust-banner-sdk #onetrust-reject-all-handler, #onetrust-banner-sdk #onetrust-pc-btn-handler {
+        outline-offset: 1px
+    }
+
+    #onetrust-banner-sdk .ot-close-icon, #onetrust-pc-sdk .ot-close-icon, #ot-sync-ntfy .ot-close-icon {
+        background-image: url("data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IiB3aWR0aD0iMzQ4LjMzM3B4IiBoZWlnaHQ9IjM0OC4zMzNweCIgdmlld0JveD0iMCAwIDM0OC4zMzMgMzQ4LjMzNCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzQ4LjMzMyAzNDguMzM0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PGc+PHBhdGggZmlsbD0iIzU2NTY1NiIgZD0iTTMzNi41NTksNjguNjExTDIzMS4wMTYsMTc0LjE2NWwxMDUuNTQzLDEwNS41NDljMTUuNjk5LDE1LjcwNSwxNS42OTksNDEuMTQ1LDAsNTYuODVjLTcuODQ0LDcuODQ0LTE4LjEyOCwxMS43NjktMjguNDA3LDExLjc2OWMtMTAuMjk2LDAtMjAuNTgxLTMuOTE5LTI4LjQxOS0xMS43NjlMMTc0LjE2NywyMzEuMDAzTDY4LjYwOSwzMzYuNTYzYy03Ljg0Myw3Ljg0NC0xOC4xMjgsMTEuNzY5LTI4LjQxNiwxMS43NjljLTEwLjI4NSwwLTIwLjU2My0zLjkxOS0yOC40MTMtMTEuNzY5Yy0xNS42OTktMTUuNjk4LTE1LjY5OS00MS4xMzksMC01Ni44NWwxMDUuNTQtMTA1LjU0OUwxMS43NzQsNjguNjExYy0xNS42OTktMTUuNjk5LTE1LjY5OS00MS4xNDUsMC01Ni44NDRjMTUuNjk2LTE1LjY4Nyw0MS4xMjctMTUuNjg3LDU2LjgyOSwwbDEwNS41NjMsMTA1LjU1NEwyNzkuNzIxLDExLjc2N2MxNS43MDUtMTUuNjg3LDQxLjEzOS0xNS42ODcsNTYuODMyLDBDMzUyLjI1OCwyNy40NjYsMzUyLjI1OCw1Mi45MTIsMzM2LjU1OSw2OC42MTF6Ii8+PC9nPjwvc3ZnPg==");
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-position: center;
+        height: 12px;
+        width: 12px
+    }
+
+    #onetrust-banner-sdk .powered-by-logo, #onetrust-banner-sdk .ot-pc-footer-logo a, #onetrust-pc-sdk .powered-by-logo, #onetrust-pc-sdk .ot-pc-footer-logo a, #ot-sync-ntfy .powered-by-logo, #ot-sync-ntfy .ot-pc-footer-logo a {
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-position: center;
+        height: 25px;
+        width: 152px;
+        display: block
+    }
+
+    #onetrust-banner-sdk h3 *, #onetrust-banner-sdk h4 *, #onetrust-banner-sdk h6 *, #onetrust-banner-sdk button *, #onetrust-banner-sdk a[data-parent-id] *, #onetrust-pc-sdk h3 *, #onetrust-pc-sdk h4 *, #onetrust-pc-sdk h6 *, #onetrust-pc-sdk button *, #onetrust-pc-sdk a[data-parent-id] *, #ot-sync-ntfy h3 *, #ot-sync-ntfy h4 *, #ot-sync-ntfy h6 *, #ot-sync-ntfy button *, #ot-sync-ntfy a[data-parent-id] * {
+        font-size: inherit;
+        font-weight: inherit;
+        color: inherit
+    }
+
+    #onetrust-banner-sdk .ot-hide, #onetrust-pc-sdk .ot-hide, #ot-sync-ntfy .ot-hide {
+        display: none !important
+    }
+
+    #onetrust-pc-sdk .ot-sdk-row .ot-sdk-column {
+        padding: 0
+    }
+
+    #onetrust-pc-sdk .ot-sdk-container {
+        padding-right: 0
+    }
+
+    #onetrust-pc-sdk .ot-sdk-row {
+        flex-direction: initial;
+        width: 100%
+    }
+
+    #onetrust-pc-sdk [type="checkbox"]:checked, #onetrust-pc-sdk [type="checkbox"]:not(:checked) {
+        pointer-events: initial
+    }
+
+    #onetrust-pc-sdk [type="checkbox"]:disabled + label::before, #onetrust-pc-sdk [type="checkbox"]:disabled + label:after, #onetrust-pc-sdk [type="checkbox"]:disabled + label {
+        pointer-events: none;
+        opacity: 0.7
+    }
+
+    #onetrust-pc-sdk #vendor-list-content {
+        transform: translate3d(0, 0, 0)
+    }
+
+    #onetrust-pc-sdk li input[type="checkbox"] {
+        z-index: 1
+    }
+
+    #onetrust-pc-sdk li .ot-checkbox label {
+        z-index: 2
+    }
+
+    #onetrust-pc-sdk li .ot-checkbox input[type="checkbox"] {
+        height: auto;
+        width: auto
+    }
+
+    #onetrust-pc-sdk li .host-title a, #onetrust-pc-sdk li .ot-host-name a, #onetrust-pc-sdk li .accordion-text, #onetrust-pc-sdk li .ot-acc-txt {
+        z-index: 2;
+        position: relative
+    }
+
+    #onetrust-pc-sdk input {
+        margin: 3px 0.1ex
+    }
+
+    #onetrust-pc-sdk .pc-logo, #onetrust-pc-sdk .ot-pc-logo {
+        height: 60px;
+        width: 180px;
+        background-position: center;
+        background-size: contain;
+        background-repeat: no-repeat
+    }
+
+    #onetrust-pc-sdk .screen-reader-only, #onetrust-pc-sdk .ot-scrn-rdr, .ot-sdk-cookie-policy .screen-reader-only, .ot-sdk-cookie-policy .ot-scrn-rdr {
+        border: 0;
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px
+    }
+
+    #onetrust-pc-sdk.ot-fade-in, .onetrust-pc-dark-filter.ot-fade-in, #onetrust-banner-sdk.ot-fade-in {
+        animation-name: onetrust-fade-in;
+        animation-duration: 400ms;
+        animation-timing-function: ease-in-out
+    }
+
+    #onetrust-pc-sdk.ot-hide {
+        display: none !important
+    }
+
+    .onetrust-pc-dark-filter.ot-hide {
+        display: none !important
+    }
+
+    #ot-sdk-btn.ot-sdk-show-settings, #ot-sdk-btn.optanon-show-settings {
+        color: #68b631;
+        border: 1px solid #68b631;
+        height: auto;
+        white-space: normal;
+        word-wrap: break-word;
+        padding: 0.8em 2em;
+        font-size: 0.8em;
+        line-height: 1.2;
+        cursor: pointer;
+        -moz-transition: 0.1s ease;
+        -o-transition: 0.1s ease;
+        -webkit-transition: 1s ease;
+        transition: 0.1s ease
+    }
+
+    #ot-sdk-btn.ot-sdk-show-settings:hover, #ot-sdk-btn.optanon-show-settings:hover {
+        color: #fff;
+        background-color: #68b631
+    }
+
+    .onetrust-pc-dark-filter {
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 2147483646;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0
+    }
+
+    @keyframes onetrust-fade-in {
+        0% {
+            opacity: 0
+        }
+        100% {
+            opacity: 1
+        }
+    }
+
+    .ot-cookie-label {
+        text-decoration: underline
+    }
+
+    @media only screen and (min-width: 426px) and (max-width: 896px) and (orientation: landscape) {
+        #onetrust-pc-sdk p {
+            font-size: 0.75em
+        }
+    }
+
+    #onetrust-banner-sdk .banner-option-input:focus + label {
+        outline: 1px solid #000;
+        outline-style: auto
+    }
+
+    .category-vendors-list-handler + a:focus, .category-vendors-list-handler + a:focus-visible {
+        outline: 2px solid #000
+    }
+
+    #onetrust-banner-sdk, #onetrust-pc-sdk, #ot-sdk-cookie-policy, #ot-sync-ntfy {
+        font-size: 16px
+    }
+
+    #onetrust-banner-sdk *, #onetrust-banner-sdk ::after, #onetrust-banner-sdk ::before, #onetrust-pc-sdk *, #onetrust-pc-sdk ::after, #onetrust-pc-sdk ::before, #ot-sdk-cookie-policy *, #ot-sdk-cookie-policy ::after, #ot-sdk-cookie-policy ::before, #ot-sync-ntfy *, #ot-sync-ntfy ::after, #ot-sync-ntfy ::before {
+        -webkit-box-sizing: content-box;
+        -moz-box-sizing: content-box;
+        box-sizing: content-box
+    }
+
+    #onetrust-banner-sdk div, #onetrust-banner-sdk span, #onetrust-banner-sdk h1, #onetrust-banner-sdk h2, #onetrust-banner-sdk h3, #onetrust-banner-sdk h4, #onetrust-banner-sdk h5, #onetrust-banner-sdk h6, #onetrust-banner-sdk p, #onetrust-banner-sdk img, #onetrust-banner-sdk svg, #onetrust-banner-sdk button, #onetrust-banner-sdk section, #onetrust-banner-sdk a, #onetrust-banner-sdk label, #onetrust-banner-sdk input, #onetrust-banner-sdk ul, #onetrust-banner-sdk li, #onetrust-banner-sdk nav, #onetrust-banner-sdk table, #onetrust-banner-sdk thead, #onetrust-banner-sdk tr, #onetrust-banner-sdk td, #onetrust-banner-sdk tbody, #onetrust-banner-sdk .ot-main-content, #onetrust-banner-sdk .ot-toggle, #onetrust-banner-sdk #ot-content, #onetrust-banner-sdk #ot-pc-content, #onetrust-banner-sdk .checkbox, #onetrust-pc-sdk div, #onetrust-pc-sdk span, #onetrust-pc-sdk h1, #onetrust-pc-sdk h2, #onetrust-pc-sdk h3, #onetrust-pc-sdk h4, #onetrust-pc-sdk h5, #onetrust-pc-sdk h6, #onetrust-pc-sdk p, #onetrust-pc-sdk img, #onetrust-pc-sdk svg, #onetrust-pc-sdk button, #onetrust-pc-sdk section, #onetrust-pc-sdk a, #onetrust-pc-sdk label, #onetrust-pc-sdk input, #onetrust-pc-sdk ul, #onetrust-pc-sdk li, #onetrust-pc-sdk nav, #onetrust-pc-sdk table, #onetrust-pc-sdk thead, #onetrust-pc-sdk tr, #onetrust-pc-sdk td, #onetrust-pc-sdk tbody, #onetrust-pc-sdk .ot-main-content, #onetrust-pc-sdk .ot-toggle, #onetrust-pc-sdk #ot-content, #onetrust-pc-sdk #ot-pc-content, #onetrust-pc-sdk .checkbox, #ot-sdk-cookie-policy div, #ot-sdk-cookie-policy span, #ot-sdk-cookie-policy h1, #ot-sdk-cookie-policy h2, #ot-sdk-cookie-policy h3, #ot-sdk-cookie-policy h4, #ot-sdk-cookie-policy h5, #ot-sdk-cookie-policy h6, #ot-sdk-cookie-policy p, #ot-sdk-cookie-policy img, #ot-sdk-cookie-policy svg, #ot-sdk-cookie-policy button, #ot-sdk-cookie-policy section, #ot-sdk-cookie-policy a, #ot-sdk-cookie-policy label, #ot-sdk-cookie-policy input, #ot-sdk-cookie-policy ul, #ot-sdk-cookie-policy li, #ot-sdk-cookie-policy nav, #ot-sdk-cookie-policy table, #ot-sdk-cookie-policy thead, #ot-sdk-cookie-policy tr, #ot-sdk-cookie-policy td, #ot-sdk-cookie-policy tbody, #ot-sdk-cookie-policy .ot-main-content, #ot-sdk-cookie-policy .ot-toggle, #ot-sdk-cookie-policy #ot-content, #ot-sdk-cookie-policy #ot-pc-content, #ot-sdk-cookie-policy .checkbox, #ot-sync-ntfy div, #ot-sync-ntfy span, #ot-sync-ntfy h1, #ot-sync-ntfy h2, #ot-sync-ntfy h3, #ot-sync-ntfy h4, #ot-sync-ntfy h5, #ot-sync-ntfy h6, #ot-sync-ntfy p, #ot-sync-ntfy img, #ot-sync-ntfy svg, #ot-sync-ntfy button, #ot-sync-ntfy section, #ot-sync-ntfy a, #ot-sync-ntfy label, #ot-sync-ntfy input, #ot-sync-ntfy ul, #ot-sync-ntfy li, #ot-sync-ntfy nav, #ot-sync-ntfy table, #ot-sync-ntfy thead, #ot-sync-ntfy tr, #ot-sync-ntfy td, #ot-sync-ntfy tbody, #ot-sync-ntfy .ot-main-content, #ot-sync-ntfy .ot-toggle, #ot-sync-ntfy #ot-content, #ot-sync-ntfy #ot-pc-content, #ot-sync-ntfy .checkbox {
+        font-family: inherit;
+        font-weight: normal;
+        -webkit-font-smoothing: auto;
+        letter-spacing: normal;
+        line-height: normal;
+        padding: 0;
+        margin: 0;
+        height: auto;
+        min-height: 0;
+        max-height: none;
+        width: auto;
+        min-width: 0;
+        max-width: none;
+        border-radius: 0;
+        border: none;
+        clear: none;
+        float: none;
+        position: static;
+        bottom: auto;
+        left: auto;
+        right: auto;
+        top: auto;
+        text-align: left;
+        text-decoration: none;
+        text-indent: 0;
+        text-shadow: none;
+        text-transform: none;
+        white-space: normal;
+        background: none;
+        overflow: visible;
+        vertical-align: baseline;
+        visibility: visible;
+        z-index: auto;
+        box-shadow: none
+    }
+
+    #onetrust-banner-sdk label:before, #onetrust-banner-sdk label:after, #onetrust-banner-sdk .checkbox:after, #onetrust-banner-sdk .checkbox:before, #onetrust-pc-sdk label:before, #onetrust-pc-sdk label:after, #onetrust-pc-sdk .checkbox:after, #onetrust-pc-sdk .checkbox:before, #ot-sdk-cookie-policy label:before, #ot-sdk-cookie-policy label:after, #ot-sdk-cookie-policy .checkbox:after, #ot-sdk-cookie-policy .checkbox:before, #ot-sync-ntfy label:before, #ot-sync-ntfy label:after, #ot-sync-ntfy .checkbox:after, #ot-sync-ntfy .checkbox:before {
+        content: "";
+        content: none
+    }
+
+    #onetrust-banner-sdk .ot-sdk-container, #onetrust-pc-sdk .ot-sdk-container, #ot-sdk-cookie-policy .ot-sdk-container {
+        position: relative;
+        width: 100%;
+        max-width: 100%;
+        margin: 0 auto;
+        padding: 0 20px;
+        box-sizing: border-box
+    }
+
+    #onetrust-banner-sdk .ot-sdk-column, #onetrust-banner-sdk .ot-sdk-columns, #onetrust-pc-sdk .ot-sdk-column, #onetrust-pc-sdk .ot-sdk-columns, #ot-sdk-cookie-policy .ot-sdk-column, #ot-sdk-cookie-policy .ot-sdk-columns {
+        width: 100%;
+        float: left;
+        box-sizing: border-box;
+        padding: 0;
+        display: initial
+    }
+
+    @media (min-width: 400px) {
+        #onetrust-banner-sdk .ot-sdk-container, #onetrust-pc-sdk .ot-sdk-container, #ot-sdk-cookie-policy .ot-sdk-container {
+            width: 90%;
+            padding: 0
+        }
+    }
+
+    @media (min-width: 550px) {
+        #onetrust-banner-sdk .ot-sdk-container, #onetrust-pc-sdk .ot-sdk-container, #ot-sdk-cookie-policy .ot-sdk-container {
+            width: 100%
+        }
+
+        #onetrust-banner-sdk .ot-sdk-column, #onetrust-banner-sdk .ot-sdk-columns, #onetrust-pc-sdk .ot-sdk-column, #onetrust-pc-sdk .ot-sdk-columns, #ot-sdk-cookie-policy .ot-sdk-column, #ot-sdk-cookie-policy .ot-sdk-columns {
+            margin-left: 4%
+        }
+
+        #onetrust-banner-sdk .ot-sdk-column:first-child, #onetrust-banner-sdk .ot-sdk-columns:first-child, #onetrust-pc-sdk .ot-sdk-column:first-child, #onetrust-pc-sdk .ot-sdk-columns:first-child, #ot-sdk-cookie-policy .ot-sdk-column:first-child, #ot-sdk-cookie-policy .ot-sdk-columns:first-child {
+            margin-left: 0
+        }
+
+        #onetrust-banner-sdk .ot-sdk-two.ot-sdk-columns, #onetrust-pc-sdk .ot-sdk-two.ot-sdk-columns, #ot-sdk-cookie-policy .ot-sdk-two.ot-sdk-columns {
+            width: 13.3333333333%
+        }
+
+        #onetrust-banner-sdk .ot-sdk-three.ot-sdk-columns, #onetrust-pc-sdk .ot-sdk-three.ot-sdk-columns, #ot-sdk-cookie-policy .ot-sdk-three.ot-sdk-columns {
+            width: 22%
+        }
+
+        #onetrust-banner-sdk .ot-sdk-four.ot-sdk-columns, #onetrust-pc-sdk .ot-sdk-four.ot-sdk-columns, #ot-sdk-cookie-policy .ot-sdk-four.ot-sdk-columns {
+            width: 30.6666666667%
+        }
+
+        #onetrust-banner-sdk .ot-sdk-eight.ot-sdk-columns, #onetrust-pc-sdk .ot-sdk-eight.ot-sdk-columns, #ot-sdk-cookie-policy .ot-sdk-eight.ot-sdk-columns {
+            width: 65.3333333333%
+        }
+
+        #onetrust-banner-sdk .ot-sdk-nine.ot-sdk-columns, #onetrust-pc-sdk .ot-sdk-nine.ot-sdk-columns, #ot-sdk-cookie-policy .ot-sdk-nine.ot-sdk-columns {
+            width: 74%
+        }
+
+        #onetrust-banner-sdk .ot-sdk-ten.ot-sdk-columns, #onetrust-pc-sdk .ot-sdk-ten.ot-sdk-columns, #ot-sdk-cookie-policy .ot-sdk-ten.ot-sdk-columns {
+            width: 82.6666666667%
+        }
+
+        #onetrust-banner-sdk .ot-sdk-eleven.ot-sdk-columns, #onetrust-pc-sdk .ot-sdk-eleven.ot-sdk-columns, #ot-sdk-cookie-policy .ot-sdk-eleven.ot-sdk-columns {
+            width: 91.3333333333%
+        }
+
+        #onetrust-banner-sdk .ot-sdk-twelve.ot-sdk-columns, #onetrust-pc-sdk .ot-sdk-twelve.ot-sdk-columns, #ot-sdk-cookie-policy .ot-sdk-twelve.ot-sdk-columns {
+            width: 100%;
+            margin-left: 0
+        }
+    }
+
+    #onetrust-banner-sdk h1, #onetrust-banner-sdk h2, #onetrust-banner-sdk h3, #onetrust-banner-sdk h4, #onetrust-banner-sdk h5, #onetrust-banner-sdk h6, #onetrust-pc-sdk h1, #onetrust-pc-sdk h2, #onetrust-pc-sdk h3, #onetrust-pc-sdk h4, #onetrust-pc-sdk h5, #onetrust-pc-sdk h6, #ot-sdk-cookie-policy h1, #ot-sdk-cookie-policy h2, #ot-sdk-cookie-policy h3, #ot-sdk-cookie-policy h4, #ot-sdk-cookie-policy h5, #ot-sdk-cookie-policy h6 {
+        margin-top: 0;
+        font-weight: 600;
+        font-family: inherit
+    }
+
+    #onetrust-banner-sdk h1, #onetrust-pc-sdk h1, #ot-sdk-cookie-policy h1 {
+        font-size: 1.5rem;
+        line-height: 1.2
+    }
+
+    #onetrust-banner-sdk h2, #onetrust-pc-sdk h2, #ot-sdk-cookie-policy h2 {
+        font-size: 1.5rem;
+        line-height: 1.25
+    }
+
+    #onetrust-banner-sdk h3, #onetrust-pc-sdk h3, #ot-sdk-cookie-policy h3 {
+        font-size: 1.5rem;
+        line-height: 1.3
+    }
+
+    #onetrust-banner-sdk h4, #onetrust-pc-sdk h4, #ot-sdk-cookie-policy h4 {
+        font-size: 1.5rem;
+        line-height: 1.35
+    }
+
+    #onetrust-banner-sdk h5, #onetrust-pc-sdk h5, #ot-sdk-cookie-policy h5 {
+        font-size: 1.5rem;
+        line-height: 1.5
+    }
+
+    #onetrust-banner-sdk h6, #onetrust-pc-sdk h6, #ot-sdk-cookie-policy h6 {
+        font-size: 1.5rem;
+        line-height: 1.6
+    }
+
+    @media (min-width: 550px) {
+        #onetrust-banner-sdk h1, #onetrust-pc-sdk h1, #ot-sdk-cookie-policy h1 {
+            font-size: 1.5rem
+        }
+
+        #onetrust-banner-sdk h2, #onetrust-pc-sdk h2, #ot-sdk-cookie-policy h2 {
+            font-size: 1.5rem
+        }
+
+        #onetrust-banner-sdk h3, #onetrust-pc-sdk h3, #ot-sdk-cookie-policy h3 {
+            font-size: 1.5rem
+        }
+
+        #onetrust-banner-sdk h4, #onetrust-pc-sdk h4, #ot-sdk-cookie-policy h4 {
+            font-size: 1.5rem
+        }
+
+        #onetrust-banner-sdk h5, #onetrust-pc-sdk h5, #ot-sdk-cookie-policy h5 {
+            font-size: 1.5rem
+        }
+
+        #onetrust-banner-sdk h6, #onetrust-pc-sdk h6, #ot-sdk-cookie-policy h6 {
+            font-size: 1.5rem
+        }
+    }
+
+    #onetrust-banner-sdk p, #onetrust-pc-sdk p, #ot-sdk-cookie-policy p {
+        margin: 0 0 1em 0;
+        font-family: inherit;
+        line-height: normal
+    }
+
+    #onetrust-banner-sdk a, #onetrust-pc-sdk a, #ot-sdk-cookie-policy a {
+        color: #565656;
+        text-decoration: underline
+    }
+
+    #onetrust-banner-sdk a:hover, #onetrust-pc-sdk a:hover, #ot-sdk-cookie-policy a:hover {
+        color: #565656;
+        text-decoration: none
+    }
+
+    #onetrust-banner-sdk .ot-sdk-button, #onetrust-banner-sdk button, #onetrust-pc-sdk .ot-sdk-button, #onetrust-pc-sdk button, #ot-sdk-cookie-policy .ot-sdk-button, #ot-sdk-cookie-policy button {
+        margin-bottom: 1rem;
+        font-family: inherit
+    }
+
+    #onetrust-banner-sdk .ot-sdk-button, #onetrust-banner-sdk button, #onetrust-pc-sdk .ot-sdk-button, #onetrust-pc-sdk button, #ot-sdk-cookie-policy .ot-sdk-button, #ot-sdk-cookie-policy button {
+        display: inline-block;
+        height: 38px;
+        padding: 0 30px;
+        color: #555;
+        text-align: center;
+        font-size: 0.9em;
+        font-weight: 400;
+        line-height: 38px;
+        letter-spacing: 0.01em;
+        text-decoration: none;
+        white-space: nowrap;
+        background-color: transparent;
+        border-radius: 2px;
+        border: 1px solid #bbb;
+        cursor: pointer;
+        box-sizing: border-box
+    }
+
+    #onetrust-banner-sdk .ot-sdk-button:hover, #onetrust-banner-sdk :not(.ot-leg-btn-container) > button:hover, #onetrust-banner-sdk :not(.ot-leg-btn-container) > button:focus, #onetrust-pc-sdk .ot-sdk-button:hover, #onetrust-pc-sdk :not(.ot-leg-btn-container) > button:hover, #onetrust-pc-sdk :not(.ot-leg-btn-container) > button:focus, #ot-sdk-cookie-policy .ot-sdk-button:hover, #ot-sdk-cookie-policy :not(.ot-leg-btn-container) > button:hover, #ot-sdk-cookie-policy :not(.ot-leg-btn-container) > button:focus {
+        color: #333;
+        border-color: #888;
+        opacity: 0.7
+    }
+
+    #onetrust-banner-sdk .ot-sdk-button:focus, #onetrust-banner-sdk :not(.ot-leg-btn-container) > button:focus, #onetrust-pc-sdk .ot-sdk-button:focus, #onetrust-pc-sdk :not(.ot-leg-btn-container) > button:focus, #ot-sdk-cookie-policy .ot-sdk-button:focus, #ot-sdk-cookie-policy :not(.ot-leg-btn-container) > button:focus {
+        outline: 2px solid #000
+    }
+
+    #onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary, #onetrust-banner-sdk button.ot-sdk-button-primary, #onetrust-banner-sdk input[type="submit"].ot-sdk-button-primary, #onetrust-banner-sdk input[type="reset"].ot-sdk-button-primary, #onetrust-banner-sdk input[type="button"].ot-sdk-button-primary, #onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary, #onetrust-pc-sdk button.ot-sdk-button-primary, #onetrust-pc-sdk input[type="submit"].ot-sdk-button-primary, #onetrust-pc-sdk input[type="reset"].ot-sdk-button-primary, #onetrust-pc-sdk input[type="button"].ot-sdk-button-primary, #ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary, #ot-sdk-cookie-policy button.ot-sdk-button-primary, #ot-sdk-cookie-policy input[type="submit"].ot-sdk-button-primary, #ot-sdk-cookie-policy input[type="reset"].ot-sdk-button-primary, #ot-sdk-cookie-policy input[type="button"].ot-sdk-button-primary {
+        color: #fff;
+        background-color: #33c3f0;
+        border-color: #33c3f0
+    }
+
+    #onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:hover, #onetrust-banner-sdk button.ot-sdk-button-primary:hover, #onetrust-banner-sdk input[type="submit"].ot-sdk-button-primary:hover, #onetrust-banner-sdk input[type="reset"].ot-sdk-button-primary:hover, #onetrust-banner-sdk input[type="button"].ot-sdk-button-primary:hover, #onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:focus, #onetrust-banner-sdk button.ot-sdk-button-primary:focus, #onetrust-banner-sdk input[type="submit"].ot-sdk-button-primary:focus, #onetrust-banner-sdk input[type="reset"].ot-sdk-button-primary:focus, #onetrust-banner-sdk input[type="button"].ot-sdk-button-primary:focus, #onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:hover, #onetrust-pc-sdk button.ot-sdk-button-primary:hover, #onetrust-pc-sdk input[type="submit"].ot-sdk-button-primary:hover, #onetrust-pc-sdk input[type="reset"].ot-sdk-button-primary:hover, #onetrust-pc-sdk input[type="button"].ot-sdk-button-primary:hover, #onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:focus, #onetrust-pc-sdk button.ot-sdk-button-primary:focus, #onetrust-pc-sdk input[type="submit"].ot-sdk-button-primary:focus, #onetrust-pc-sdk input[type="reset"].ot-sdk-button-primary:focus, #onetrust-pc-sdk input[type="button"].ot-sdk-button-primary:focus, #ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:hover, #ot-sdk-cookie-policy button.ot-sdk-button-primary:hover, #ot-sdk-cookie-policy input[type="submit"].ot-sdk-button-primary:hover, #ot-sdk-cookie-policy input[type="reset"].ot-sdk-button-primary:hover, #ot-sdk-cookie-policy input[type="button"].ot-sdk-button-primary:hover, #ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:focus, #ot-sdk-cookie-policy button.ot-sdk-button-primary:focus, #ot-sdk-cookie-policy input[type="submit"].ot-sdk-button-primary:focus, #ot-sdk-cookie-policy input[type="reset"].ot-sdk-button-primary:focus, #ot-sdk-cookie-policy input[type="button"].ot-sdk-button-primary:focus {
+        color: #fff;
+        background-color: #1eaedb;
+        border-color: #1eaedb
+    }
+
+    #onetrust-banner-sdk input[type="text"], #onetrust-pc-sdk input[type="text"], #ot-sdk-cookie-policy input[type="text"] {
+        height: 38px;
+        padding: 6px 10px;
+        background-color: #fff;
+        border: 1px solid #d1d1d1;
+        border-radius: 4px;
+        box-shadow: none;
+        box-sizing: border-box
+    }
+
+    #onetrust-banner-sdk input[type="text"], #onetrust-pc-sdk input[type="text"], #ot-sdk-cookie-policy input[type="text"] {
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none
+    }
+
+    #onetrust-banner-sdk input[type="text"]:focus, #onetrust-pc-sdk input[type="text"]:focus, #ot-sdk-cookie-policy input[type="text"]:focus {
+        border: 1px solid #000;
+        outline: 0
+    }
+
+    #onetrust-banner-sdk label, #onetrust-pc-sdk label, #ot-sdk-cookie-policy label {
+        display: block;
+        margin-bottom: 0.5rem;
+        font-weight: 600
+    }
+
+    #onetrust-banner-sdk input[type="checkbox"], #onetrust-pc-sdk input[type="checkbox"], #ot-sdk-cookie-policy input[type="checkbox"] {
+        display: inline
+    }
+
+    #onetrust-banner-sdk ul, #onetrust-pc-sdk ul, #ot-sdk-cookie-policy ul {
+        list-style: circle inside
+    }
+
+    #onetrust-banner-sdk ul, #onetrust-pc-sdk ul, #ot-sdk-cookie-policy ul {
+        padding-left: 0;
+        margin-top: 0
+    }
+
+    #onetrust-banner-sdk ul ul, #onetrust-pc-sdk ul ul, #ot-sdk-cookie-policy ul ul {
+        margin: 1.5rem 0 1.5rem 3rem;
+        font-size: 90%
+    }
+
+    #onetrust-banner-sdk li, #onetrust-pc-sdk li, #ot-sdk-cookie-policy li {
+        margin-bottom: 1rem
+    }
+
+    #onetrust-banner-sdk th, #onetrust-banner-sdk td, #onetrust-pc-sdk th, #onetrust-pc-sdk td, #ot-sdk-cookie-policy th, #ot-sdk-cookie-policy td {
+        padding: 12px 15px;
+        text-align: left;
+        border-bottom: 1px solid #e1e1e1
+    }
+
+    #onetrust-banner-sdk button, #onetrust-pc-sdk button, #ot-sdk-cookie-policy button {
+        margin-bottom: 1rem;
+        font-family: inherit
+    }
+
+    #onetrust-banner-sdk .ot-sdk-container:after, #onetrust-banner-sdk .ot-sdk-row:after, #onetrust-pc-sdk .ot-sdk-container:after, #onetrust-pc-sdk .ot-sdk-row:after, #ot-sdk-cookie-policy .ot-sdk-container:after, #ot-sdk-cookie-policy .ot-sdk-row:after {
+        content: "";
+        display: table;
+        clear: both
+    }
+
+    #onetrust-banner-sdk .ot-sdk-row, #onetrust-pc-sdk .ot-sdk-row, #ot-sdk-cookie-policy .ot-sdk-row {
+        margin: 0;
+        max-width: none;
+        display: block
+    }
+
+    #onetrust-banner-sdk {
+        box-shadow: 0 0 18px rgba(0, 0, 0, .2)
+    }
+
+    #onetrust-banner-sdk.otFlat {
+        position: fixed;
+        z-index: 2147483645;
+        bottom: 0;
+        right: 0;
+        left: 0;
+        background-color: #fff;
+        max-height: 90%;
+        overflow-x: hidden;
+        overflow-y: auto
+    }
+
+    #onetrust-banner-sdk.otFlat.top {
+        top: 0px;
+        bottom: auto
+    }
+
+    #onetrust-banner-sdk.otRelFont {
+        font-size: 1rem
+    }
+
+    #onetrust-banner-sdk > .ot-sdk-container {
+        overflow: hidden
+    }
+
+    #onetrust-banner-sdk::-webkit-scrollbar {
+        width: 11px
+    }
+
+    #onetrust-banner-sdk::-webkit-scrollbar-thumb {
+        border-radius: 10px;
+        background: #c1c1c1
+    }
+
+    #onetrust-banner-sdk {
+        scrollbar-arrow-color: #c1c1c1;
+        scrollbar-darkshadow-color: #c1c1c1;
+        scrollbar-face-color: #c1c1c1;
+        scrollbar-shadow-color: #c1c1c1
+    }
+
+    #onetrust-banner-sdk #onetrust-policy {
+        margin: 1.25em 0 .625em 2em;
+        overflow: hidden
+    }
+
+    #onetrust-banner-sdk #onetrust-policy .ot-gv-list-handler {
+        float: left;
+        font-size: .82em;
+        padding: 0;
+        margin-bottom: 0;
+        border: 0;
+        line-height: normal;
+        height: auto;
+        width: auto
+    }
+
+    #onetrust-banner-sdk #onetrust-policy-title {
+        font-size: 1.2em;
+        line-height: 1.3;
+        margin-bottom: 10px
+    }
+
+    #onetrust-banner-sdk #onetrust-policy-text {
+        clear: both;
+        text-align: left;
+        font-size: .88em;
+        line-height: 1.4
+    }
+
+    #onetrust-banner-sdk #onetrust-policy-text * {
+        font-size: inherit;
+        line-height: inherit
+    }
+
+    #onetrust-banner-sdk #onetrust-policy-text a {
+        font-weight: bold;
+        margin-left: 5px
+    }
+
+    #onetrust-banner-sdk #onetrust-policy-title, #onetrust-banner-sdk #onetrust-policy-text {
+        color: dimgray;
+        float: left
+    }
+
+    #onetrust-banner-sdk #onetrust-button-group-parent {
+        min-height: 1px;
+        text-align: center
+    }
+
+    #onetrust-banner-sdk #onetrust-button-group {
+        display: inline-block
+    }
+
+    #onetrust-banner-sdk #onetrust-accept-btn-handler, #onetrust-banner-sdk #onetrust-reject-all-handler, #onetrust-banner-sdk #onetrust-pc-btn-handler {
+        background-color: #68b631;
+        color: #fff;
+        border-color: #68b631;
+        margin-right: 1em;
+        min-width: 125px;
+        height: auto;
+        white-space: normal;
+        word-break: break-word;
+        word-wrap: break-word;
+        padding: 12px 10px;
+        line-height: 1.2;
+        font-size: .813em;
+        font-weight: 600
+    }
+
+    #onetrust-banner-sdk #onetrust-pc-btn-handler.cookie-setting-link {
+        background-color: #fff;
+        border: none;
+        color: #68b631;
+        text-decoration: underline;
+        padding-left: 0;
+        padding-right: 0
+    }
+
+    #onetrust-banner-sdk .onetrust-close-btn-ui {
+        width: 44px;
+        height: 44px;
+        background-size: 12px;
+        border: none;
+        position: relative;
+        margin: auto;
+        padding: 0
+    }
+
+    #onetrust-banner-sdk .banner_logo {
+        display: none
+    }
+
+    #onetrust-banner-sdk .ot-b-addl-desc {
+        clear: both;
+        float: left;
+        display: block
+    }
+
+    #onetrust-banner-sdk #banner-options {
+        float: left;
+        display: table;
+        margin-right: 0;
+        margin-left: 1em;
+        width: calc(100% - 1em)
+    }
+
+    #onetrust-banner-sdk .banner-option-input {
+        cursor: pointer;
+        width: auto;
+        height: auto;
+        border: none;
+        padding: 0;
+        padding-right: 3px;
+        margin: 0 0 10px;
+        font-size: .82em;
+        line-height: 1.4
+    }
+
+    #onetrust-banner-sdk .banner-option-input * {
+        pointer-events: none;
+        font-size: inherit;
+        line-height: inherit
+    }
+
+    #onetrust-banner-sdk .banner-option-input[aria-expanded=true] ~ .banner-option-details {
+        display: block;
+        height: auto
+    }
+
+    #onetrust-banner-sdk .banner-option-input[aria-expanded=true] .ot-arrow-container {
+        transform: rotate(90deg)
+    }
+
+    #onetrust-banner-sdk .banner-option {
+        margin-bottom: 12px;
+        margin-left: 0;
+        border: none;
+        float: left;
+        padding: 0
+    }
+
+    #onetrust-banner-sdk .banner-option:first-child {
+        padding-left: 2px
+    }
+
+    #onetrust-banner-sdk .banner-option:not(:first-child) {
+        padding: 0;
+        border: none
+    }
+
+    #onetrust-banner-sdk .banner-option-header {
+        cursor: pointer;
+        display: inline-block
+    }
+
+    #onetrust-banner-sdk .banner-option-header :first-child {
+        color: dimgray;
+        font-weight: bold;
+        float: left
+    }
+
+    #onetrust-banner-sdk .banner-option-header .ot-arrow-container {
+        display: inline-block;
+        border-top: 6px solid transparent;
+        border-bottom: 6px solid transparent;
+        border-left: 6px solid dimgray;
+        margin-left: 10px;
+        vertical-align: middle
+    }
+
+    #onetrust-banner-sdk .banner-option-details {
+        display: none;
+        font-size: .83em;
+        line-height: 1.5;
+        padding: 10px 0px 5px 10px;
+        margin-right: 10px;
+        height: 0px
+    }
+
+    #onetrust-banner-sdk .banner-option-details * {
+        font-size: inherit;
+        line-height: inherit;
+        color: dimgray
+    }
+
+    #onetrust-banner-sdk .ot-arrow-container, #onetrust-banner-sdk .banner-option-details {
+        transition: all 300ms ease-in 0s;
+        -webkit-transition: all 300ms ease-in 0s;
+        -moz-transition: all 300ms ease-in 0s;
+        -o-transition: all 300ms ease-in 0s
+    }
+
+    #onetrust-banner-sdk .ot-dpd-container {
+        float: left
+    }
+
+    #onetrust-banner-sdk .ot-dpd-title {
+        margin-bottom: 10px
+    }
+
+    #onetrust-banner-sdk .ot-dpd-title, #onetrust-banner-sdk .ot-dpd-desc {
+        font-size: .88em;
+        line-height: 1.4;
+        color: dimgray
+    }
+
+    #onetrust-banner-sdk .ot-dpd-title *, #onetrust-banner-sdk .ot-dpd-desc * {
+        font-size: inherit;
+        line-height: inherit
+    }
+
+    #onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text * {
+        margin-bottom: 0
+    }
+
+    #onetrust-banner-sdk.ot-iab-2 .onetrust-vendors-list-handler {
+        display: block;
+        margin-left: 0;
+        margin-top: 5px;
+        clear: both;
+        margin-bottom: 0;
+        padding: 0;
+        border: 0;
+        height: auto;
+        width: auto
+    }
+
+    #onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button {
+        display: block
+    }
+
+    #onetrust-banner-sdk.ot-close-btn-link {
+        padding-top: 25px
+    }
+
+    #onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container {
+        top: 15px;
+        transform: none;
+        right: 15px
+    }
+
+    #onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container button {
+        padding: 0;
+        white-space: pre-wrap;
+        border: none;
+        height: auto;
+        line-height: 1.5;
+        text-decoration: underline;
+        font-size: .69em
+    }
+
+    #onetrust-banner-sdk #onetrust-policy-text, #onetrust-banner-sdk .ot-dpd-desc, #onetrust-banner-sdk .ot-b-addl-desc {
+        font-size: .813em;
+        line-height: 1.5
+    }
+
+    #onetrust-banner-sdk .ot-dpd-desc {
+        margin-bottom: 10px
+    }
+
+    #onetrust-banner-sdk .ot-dpd-desc > .ot-b-addl-desc {
+        margin-top: 10px;
+        margin-bottom: 10px;
+        font-size: 1em
+    }
+
+    @media only screen and (max-width: 425px) {
+        #onetrust-banner-sdk #onetrust-close-btn-container {
+            position: absolute;
+            top: 10px;
+            right: 10px
+        }
+
+        #onetrust-banner-sdk #onetrust-policy {
+            margin-left: 0
+        }
+
+        #onetrust-banner-sdk #onetrust-button-group {
+            display: block
+        }
+
+        #onetrust-banner-sdk #onetrust-accept-btn-handler, #onetrust-banner-sdk #onetrust-reject-all-handler, #onetrust-banner-sdk #onetrust-pc-btn-handler {
+            width: 100%
+        }
+
+        #onetrust-banner-sdk .onetrust-close-btn-ui {
+            top: auto;
+            transform: none
+        }
+
+        #onetrust-banner-sdk #onetrust-policy-title {
+            display: inline;
+            float: none
+        }
+
+        #onetrust-banner-sdk #banner-options {
+            margin: 0;
+            padding: 0;
+            width: 100%
+        }
+    }
+
+    @media only screen and (min-width: 426px)and (max-width: 896px) {
+        #onetrust-banner-sdk #onetrust-close-btn-container {
+            position: absolute;
+            top: 0;
+            right: 0
+        }
+
+        #onetrust-banner-sdk #onetrust-policy {
+            margin-left: 1em;
+            margin-right: 1em
+        }
+
+        #onetrust-banner-sdk .onetrust-close-btn-ui {
+            top: 10px;
+            right: 10px
+        }
+
+        #onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container {
+            width: 95%
+        }
+
+        #onetrust-banner-sdk.ot-iab-2 #onetrust-group-container {
+            width: 100%
+        }
+
+        #onetrust-banner-sdk #onetrust-button-group-parent {
+            width: 100%;
+            position: relative;
+            margin-left: 0
+        }
+
+        #onetrust-banner-sdk #onetrust-button-group button {
+            display: inline-block
+        }
+
+        #onetrust-banner-sdk #onetrust-button-group {
+            margin-right: 0;
+            text-align: center
+        }
+
+        #onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler {
+            float: left
+        }
+
+        #onetrust-banner-sdk .has-reject-all-button #onetrust-reject-all-handler, #onetrust-banner-sdk .has-reject-all-button #onetrust-accept-btn-handler {
+            float: right
+        }
+
+        #onetrust-banner-sdk .has-reject-all-button #onetrust-button-group {
+            width: calc(100% - 2em);
+            margin-right: 0
+        }
+
+        #onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler.cookie-setting-link {
+            padding-left: 0px;
+            text-align: left
+        }
+
+        #onetrust-banner-sdk.ot-buttons-fw .ot-sdk-three button {
+            width: 100%;
+            text-align: center
+        }
+
+        #onetrust-banner-sdk.ot-buttons-fw #onetrust-button-group-parent button {
+            float: none
+        }
+
+        #onetrust-banner-sdk.ot-buttons-fw #onetrust-pc-btn-handler.cookie-setting-link {
+            text-align: center
+        }
+    }
+
+    @media only screen and (min-width: 550px) {
+        #onetrust-banner-sdk .banner-option:not(:first-child) {
+            border-left: 1px solid #d8d8d8;
+            padding-left: 25px
+        }
+    }
+
+    @media only screen and (min-width: 425px)and (max-width: 550px) {
+        #onetrust-banner-sdk.ot-iab-2 #onetrust-button-group, #onetrust-banner-sdk.ot-iab-2 #onetrust-policy, #onetrust-banner-sdk.ot-iab-2 .banner-option {
+            width: 100%
+        }
+    }
+
+    @media only screen and (min-width: 769px) {
+        #onetrust-banner-sdk #onetrust-button-group {
+            margin-right: 30%
+        }
+
+        #onetrust-banner-sdk #banner-options {
+            margin-left: 2em;
+            margin-right: 5em;
+            margin-bottom: 1.25em;
+            width: calc(100% - 7em)
+        }
+    }
+
+    @media only screen and (min-width: 897px)and (max-width: 1023px) {
+        #onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent {
+            position: absolute;
+            top: 50%;
+            left: 75%;
+            transform: translateY(-50%)
+        }
+
+        #onetrust-banner-sdk #onetrust-close-btn-container {
+            top: 50%;
+            margin: auto;
+            transform: translate(-50%, -50%);
+            position: absolute;
+            padding: 0;
+            right: 0
+        }
+
+        #onetrust-banner-sdk #onetrust-close-btn-container button {
+            position: relative;
+            margin: 0;
+            right: -22px;
+            top: 2px
+        }
+    }
+
+    @media only screen and (min-width: 1024px) {
+        #onetrust-banner-sdk #onetrust-close-btn-container {
+            top: 50%;
+            margin: auto;
+            transform: translate(-50%, -50%);
+            position: absolute;
+            right: 0
+        }
+
+        #onetrust-banner-sdk #onetrust-close-btn-container button {
+            right: -12px
+        }
+
+        #onetrust-banner-sdk #onetrust-policy {
+            margin-left: 2em
+        }
+
+        #onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent {
+            position: absolute;
+            top: 50%;
+            left: 60%;
+            transform: translateY(-50%)
+        }
+
+        #onetrust-banner-sdk.ot-iab-2 #onetrust-policy-title {
+            width: 50%
+        }
+
+        #onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text, #onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc) > .ot-b-addl-desc {
+            margin-bottom: 1em;
+            width: 50%;
+            border-right: 1px solid #d8d8d8;
+            padding-right: 1rem
+        }
+
+        #onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text {
+            margin-bottom: 0;
+            padding-bottom: 1em
+        }
+
+        #onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc) > .ot-b-addl-desc {
+            margin-bottom: 0;
+            padding-bottom: 1em
+        }
+
+        #onetrust-banner-sdk.ot-iab-2 .ot-dpd-container {
+            width: 45%;
+            padding-left: 1rem;
+            display: inline-block;
+            float: none
+        }
+
+        #onetrust-banner-sdk.ot-iab-2 .ot-dpd-title {
+            line-height: 1.7
+        }
+
+        #onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent {
+            left: auto;
+            right: 4%;
+            margin-left: 0
+        }
+
+        #onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button {
+            display: block
+        }
+
+        #onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent {
+            margin: auto;
+            width: 30%
+        }
+
+        #onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container {
+            width: 60%
+        }
+
+        #onetrust-banner-sdk #onetrust-button-group {
+            margin-right: auto
+        }
+
+        #onetrust-banner-sdk #onetrust-accept-btn-handler, #onetrust-banner-sdk #onetrust-reject-all-handler, #onetrust-banner-sdk #onetrust-pc-btn-handler {
+            margin-top: 1em
+        }
+    }
+
+    @media only screen and (min-width: 890px) {
+        #onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group-parent {
+            padding-left: 3%;
+            padding-right: 4%;
+            margin-left: 0
+        }
+
+        #onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group {
+            margin-right: 0;
+            margin-top: 1.25em;
+            width: 100%
+        }
+
+        #onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button {
+            width: 100%;
+            margin-bottom: 5px;
+            margin-top: 5px
+        }
+
+        #onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button:last-of-type {
+            margin-bottom: 20px
+        }
+    }
+
+    @media only screen and (min-width: 1280px) {
+        #onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container {
+            width: 55%
+        }
+
+        #onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent {
+            width: 44%;
+            padding-left: 2%;
+            padding-right: 2%
+        }
+
+        #onetrust-banner-sdk:not(.ot-iab-2).vertical-align-content #onetrust-button-group-parent {
+            position: absolute;
+            left: 55%
+        }
+    }
+
+    #onetrust-consent-sdk #onetrust-banner-sdk {
+        background-color: #EEEEEE;
+    }
+
+    #onetrust-consent-sdk #onetrust-policy-title,
+    #onetrust-consent-sdk #onetrust-policy-text,
+    #onetrust-consent-sdk .ot-b-addl-desc,
+    #onetrust-consent-sdk .ot-dpd-desc,
+    #onetrust-consent-sdk .ot-dpd-title,
+    #onetrust-consent-sdk #onetrust-policy-text *:not(.onetrust-vendors-list-handler),
+    #onetrust-consent-sdk .ot-dpd-desc *:not(.onetrust-vendors-list-handler),
+    #onetrust-consent-sdk #onetrust-banner-sdk #banner-options *,
+    #onetrust-banner-sdk .ot-cat-header {
+        color: #181818;
+    }
+
+    #onetrust-consent-sdk #onetrust-banner-sdk .banner-option-details {
+        background-color: #E9E9E9;
+    }
+
+    #onetrust-consent-sdk #onetrust-banner-sdk a[href],
+    #onetrust-consent-sdk #onetrust-banner-sdk a[href] font,
+    #onetrust-consent-sdk #onetrust-banner-sdk .ot-link-btn {
+        color: #181818;
+    }
+
+    #onetrust-consent-sdk #onetrust-accept-btn-handler,
+    #onetrust-banner-sdk #onetrust-reject-all-handler {
+        background-color: #FFFFFF;
+        border-color: #FFFFFF;
+        color: #181818;
+    }
+
+    #onetrust-consent-sdk #onetrust-banner-sdk *:focus,
+    #onetrust-consent-sdk #onetrust-banner-sdk:focus {
+        outline-color: #000000;
+        outline-width: 1px;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-btn-handler,
+    #onetrust-consent-sdk #onetrust-pc-btn-handler.cookie-setting-link {
+        color: #001629;
+        border-color: #001629;
+        background-color: #EEEEEE;
+    }
+
+    #onetrust-banner-sdk.otFlat {
+        display: flex;
+        align-items: center;
+        min-height: 33.333%;
+    }
+
+    #onetrust-banner-sdk a#vendor_link.onetrust-vendors-list-handler {
+        color: #67b632;
+    }
+
+
+    #onetrust-pc-sdk .ot-accordion-layout .accordion-header {
+        padding-left: 12px !important;
+    }
+
+    #onetrust-banner-sdk button {
+        font-size: 14px;
+        letter-spacing: 2px;
+        color: #181818 !important;
+        font-weight: 700;
+        text-transform: uppercase;
+    }
+
+    #onetrust-banner-sdk #onetrust-accept-btn-handler {
+        line-height: 1;
+        border-radius: 500px;
+        padding: 0 43px !important;
+        opacity: 1;
+        -webkit-transition-property: background-color, border-color, color, -webkit-box-shadow, -webkit-filter;
+        transition-property: background-color, border-color, color, -webkit-box-shadow, -webkit-filter;
+        transition-property: background-color, border-color, color, box-shadow, filter;
+        transition-property: background-color, border-color, color, box-shadow, filter, -webkit-box-shadow, -webkit-filter;
+        -webkit-transition-duration: .3s;
+        transition-duration: .3s;
+        border-width: 0;
+        height: 48px;
+        min-width: 160px;
+        white-space: normal;
+        background-color: #181818 !important;
+        color: #FFFFFF !important;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 14px;
+        margin: 20px 0;
+        margin-bottom: 24px;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-btn-handler.cookie-setting-link {
+        border-radius: 500px;
+        padding: 0 !important;
+        opacity: 1;
+        border-width: 0;
+        min-width: 160px;
+        white-space: normal;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 14px;
+        text-decoration: none;
+    }
+
+    #onetrust-banner-sdk #onetrust-accept-btn-handler:active {
+        background-color: #535353 !important;
+        box-shadow: none;
+    }
+
+    #onetrust-banner-sdk #onetrust-accept-btn-handler:hover {
+        color: #FFF;
+        background-color: #535353 !important;
+        -webkit-box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1) inset;
+        box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1) inset;
+    }
+
+    #onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent {
+        position: static;
+        top: 0;
+        left: 0;
+        transform: none;
+        margin: 0;
+    }
+
+    #onetrust-banner-sdk .ot-sdk-row {
+        display: flex;
+        flex-direction: column;
+    }
+
+    #onetrust-button-group-parent {
+        width: auto !important;
+    }
+
+    #onetrust-banner-sdk .ot-sdk-container {
+        max-width: 1200px;
+        padding: 30px 24px;
+        width: 100%;
+    }
+
+    #onetrust-banner-sdk #onetrust-group-container {
+        width: 100% !important;
+    }
+
+    #onetrust-banner-sdk #onetrust-button-group {
+        display: flex;
+        flex-direction: column;
+        margin-right: 0 !important;
+    }
+
+    #onetrust-banner-sdk #onetrust-button-group button {
+        margin-right: 0;
+    }
+
+    #onetrust-pc-sdk {
+        width: 100% !important;
+        max-width: 1000px !important;
+        background-color: #FFFFFF !important;
+    }
+
+    #onetrust-pc-sdk .vendor-title {
+        color: #121212 !important;
+        font-size: 14px !important;
+    }
+
+    #onetrust-pc-sdk #vendors-list-title {
+        color: #000000 !important;
+        font-size: 24px !important;
+        margin: 10px auto 0 !important;
+        width: 100% !important;
+        max-width: 590px !important;
+    }
+
+    #onetrust-pc-sdk .vendor-privacy-notice {
+        color: #1DB954 !important;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk p {
+        color: #121212 !important;
+    }
+
+    #onetrust-consent-sdk #search-container {
+        background-color: #FFFFFF !important;
+        max-width: 590px !important;
+        margin: auto;
+        display: block;
+        float: none;
+        position: relative !important;
+    }
+
+    #onetrust-pc-sdk #search-container > svg {
+        top: 23px !important;
+        float: none !important;
+        left: 15px !important;
+        position: absolute !important;
+        right: 0 !important;
+    }
+
+    #onetrust-pc-sdk #filter-btn-handler {
+        top: 23px !important;
+        margin: 0 !important;
+    }
+
+    #onetrust-consent-sdk #vendor-search-handler {
+        border-radius: 0 !important;
+        margin: 16px 12px 0 0 !important;
+        width: calc(100% - 80px) !important;
+        height: 44px !important;
+        border: 1px solid #121212 !important;
+        max-width: 100% !important;
+    }
+
+    #onetrust-consent-sdk #vendor-search-handler::placeholder {
+        color: transparent !important;
+    }
+
+    #onetrust-consent-sdk #select-all-text-container p {
+        text-align: right !important;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk .button-theme {
+        background-color: #1DB954 !important;
+        border-color: #1DB954;
+        border-radius: 100px;
+        text-transform: uppercase;
+        font-size: 14px;
+        letter-spacing: 0.1em;
+    }
+
+    #onetrust-pc-sdk #ot-back-arrow {
+        margin: 0 !important;
+    }
+
+    #onetrust-pc-sdk .ot-checkbox input:checked ~ label::before {
+        background-color: #1DB954 !important;
+        border: 1px solid #1DB954 !important;
+    }
+
+
+    #onetrust-pc-sdk .ot-checkbox label::before {
+        border: 1px solid #B3B3B3 !important;
+    }
+
+    #onetrust-banner-sdk #onetrust-policy {
+        margin: auto;
+    }
+
+    #onetrust-banner-sdk #onetrust-policy-title {
+        font-size: 18px !important;
+        margin-bottom: 8 pm !important;
+    }
+
+    #onetrust-consent-sdk #onetrust-policy-text {
+        font-size: 12px !important;
+        line-height: 19px;
+        margin-bottom: 0;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk #pc-policy-text {
+        color: #121212 !important;
+        font-size: 14px !important;
+    }
+
+    #onetrust-pc-sdk #cookie-preferences .always-active {
+        color: #000000 !important;
+    }
+
+    #onetrust-pc-sdk .accordion-text .ot-switch {
+        background-color: #FFFFFF !important
+    }
+
+    #onetrust-pc-sdk .switch-nob {
+        background-color: #FFFFFF !important;
+        border-color: #FFFFFF !important;
+    }
+
+    #onetrust-pc-sdk .ot-switch-inner {
+        background-color: #D2D2D2 !important;
+        border-color: #D2D2D2 !important;
+    }
+
+    #onetrust-pc-sdk .ot-switch-inner:before {
+        background-color: #1DB954 !important;
+    }
+
+    #onetrust-pc-sdk .ot-switch-nob {
+        background-color: white !important;
+        border-color: white !important;
+    }
+
+    #onetrust-pc-sdk a {
+        color: #1DB954 !important;
+    }
+
+    #onetrust-pc-sdk #content {
+        max-width: 520px;
+    }
+
+    #onetrust-pc-sdk.ot-sdk-container {
+        display: flex;
+        justify-content: center;
+    }
+
+    #onetrust-pc-sdk #pc-title {
+        color: #000000 !important;
+        font-size: 24px !important;
+    }
+
+    #onetrust-pc-sdk #manage-cookies-text {
+        color: #000000 !important;
+        margin-bottom: 8px !important;
+    }
+
+
+    #onetrust-pc-sdk #cookie-preferences h4 {
+        color: #000000 !important;
+        font-size: 16px !important;
+    }
+
+    #onetrust-pc-sdk .category-item p {
+        font-size: 14px !important;
+    }
+
+    #onetrust-pc-sdk .category-vendors-list-handler {
+        font-size: 14px !important;
+        text-decoration: underline !important;
+    }
+
+    #onetrust-banner-sdk .ot-dpd-title {
+        margin-top: 16px;
+        margin-bottom: 6px !important;
+        font-size: 12px;
+    }
+
+    #onetrust-pc-sdk .switch-checkbox:checked + .ot-switch-label {
+        border-color: #1DB954 !important;
+    }
+
+    #onetrust-banner-sdk .onetrust-vendors-list-handler {
+        margin-top: 6px !important;
+        font-size: 12px !important;
+        text-decoration: underline !important;
+        font-weight: normal !important;
+    }
+
+    #onetrust-banner-sdk .onetrust-vendors-list-handler:hover {
+        color: #535353 !important;
+    }
+
+    #onetrust-banner-sdk .ot-dpd-desc {
+        font-size: 12px !important;
+    }
+
+    #onetrust-banner-sdk #onetrust-policy-text a {
+        margin: 0;
+    }
+
+    #onetrust-pc-sdk #vendors-list {
+        padding: 20px 16px 68px !important;
+        height: calc(100% - 55px) !important;
+    }
+
+    #onetrust-pc-sdk #vendors-list-header {
+        margin: 0 !important;
+    }
+
+    #onetrust-pc-sdk .back-btn-handler {
+        background-image: url('data:image/svg+xml,%3Csvg width="12" height="19" viewBox="0 0 12 19" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M10.54 18.1511L0.0949707 9.22908L10.54 0.309082L11.19 1.06908L1.63497 9.22908L11.19 17.3901L10.54 18.1511Z" fill="%23121212"/%3E%3C/svg%3E%0A');
+        height: 20px;
+        width: 20px;
+        background-repeat: no-repeat;
+    }
+
+    #onetrust-pc-sdk .back-btn-handler p {
+        display: none !important;
+    }
+
+    #onetrust-pc-sdk #vendor-close-pc-btn-handler.ot-close-icon {
+        background-image: url('data:image/svg+xml,%3Csvg width="18" height="18" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M0.929993 15.0702L15.07 0.930176M0.929993 0.930176L15.07 15.0702L0.929993 0.930176Z" stroke="%23121212" stroke-miterlimit="10"/%3E%3C/svg%3E%0A') !important;
+        height: 18px !important;
+        width: 18px !important;
+        top: 20px !important;
+        right: 16px !important;
+    }
+
+    #onetrust-pc-sdk #filter-btn-handler {
+        background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M18.831 5L13.24 11.547L13 11.827V12.196V20H11V12.196V11.827L10.76 11.547L5.169 5H18.831ZM21 4H3L10 12.196V21H14V12.196L21 4Z' fill='black'/%3E%3C/svg%3E%0A");
+        background-repeat: no-repeat;
+        background-position: center;
+        right: 0 !important;
+    }
+
+    #onetrust-pc-sdk #filter-btn-handler:hover {
+        background-color: transparent !important;
+    }
+
+    #onetrust-pc-sdk #filter-btn-handler svg {
+        display: none !important;
+    }
+
+    #onetrust-pc-sdk .pc-close-button {
+        background-image: url('data:image/svg+xml,%3Csvg width="18" height="18" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M0.929993 15.0702L15.07 0.930176M0.929993 0.930176L15.07 15.0702L0.929993 0.930176Z" stroke="%23121212" stroke-miterlimit="10"/%3E%3C/svg%3E%0A') !important;
+        height: 18px !important;
+        width: 18px !important;
+        top: 20px !important;
+        right: 16px !important;
+    }
+
+    #onetrust-pc-sdk #ot-back-arrow {
+        display: none !important;
+    }
+
+    #onetrust-pc-sdk #vendor-list-save-btn {
+        max-width: 590px !important;
+        margin: auto !important;
+    }
+
+    #onetrust-pc-sdk #vendor-list-save-btn .save-preference-btn-handler {
+        margin-top: 0 !important;
+    }
+
+    #onetrust-pc-sdk #vendor-list-content {
+        min-width: 0 !important;
+        margin: auto !important;
+        padding: 0 !important;
+        width: 100% !important;
+        max-width: 590px !important;
+        top: 15px !important;
+        height: calc(100% - 230px) !important;
+    }
+
+    #onetrust-pc-sdk #vendor-list-content .vendor-item {
+        padding: 0 !important;
+    }
+
+    #onetrust-pc-sdk #vendor-list-content .ot-sdk-column {
+        padding: 0 !important;
+    }
+
+    #onetrust-pc-sdk #vendor-list-content::-webkit-scrollbar {
+        display: none !important;
+    }
+
+    #onetrust-pc-sdk #select-all-container {
+        width: 100% !important;
+        max-width: 100% !important;
+        top: 18px !important;
+    }
+
+    #onetrust-pc-sdk #vendors-list-container .accordion-header {
+        padding: 12px 0 !important;
+    }
+
+    #onetrust-pc-sdk #select-all-container .ot-checkbox {
+        margin: auto !important;
+        display: flex !important;
+        width: 100% !important;
+        max-width: 590px !important;
+        justify-content: flex-end !important;
+        float: none !important;
+    }
+
+    #onetrust-pc-sdk #select-all-text-container {
+        width: auto !important;
+    }
+
+    #onetrust-pc-sdk #select-all-container p {
+        margin-right: 12px !important;
+    }
+
+    #onetrust-pc-sdk .ot-pc-footer-logo {
+        display: none !important;
+    }
+
+    #onetrust-pc-sdk #select-all-vendors-input-container {
+        margin-right: 41px !important;
+    }
+
+    #onetrust-pc-sdk #ot-content {
+        max-width: 590px !important;
+    }
+
+    #onetrust-pc-sdk .ot-switch.ot-toggle {
+        background-color: transparent !important;
+    }
+
+    #onetrust-pc-sdk #pc-title {
+        margin-top: 60px !important;
+    }
+
+    #onetrust-pc-sdk #accept-recommended-container button {
+        margin-top: 24px;
+    }
+
+    #onetrust-pc-sdk .vendor-info {
+        width: auto !important;
+        max-width: 30% !important;
+    }
+
+    #onetrust-pc-sdk #cookie-preferences .ot-always-active {
+        color: #000000 !important;
+        font-size: 14px;
+    }
+
+    #onetrust-pc-sdk #ot-options {
+        border-radius: 8px !important;
+        left: auto !important;
+        width: 100% !important;
+        max-width: 100% !important;
+        padding: 0 !important;
+    }
+
+    #onetrust-pc-sdk .ot-group-option {
+        width: auto !important;
+        margin-right: 25px !important;
+        margin-bottom: 18px !important;
+    }
+
+
+    #onetrust-pc-sdk #ot-filter-modal .ot-pill {
+        line-height: 1;
+        border-radius: 500px;
+        padding: 0 43px !important;
+        opacity: 1;
+        -webkit-transition-property: background-color, border-color, color, -webkit-box-shadow, -webkit-filter;
+        transition-property: background-color, border-color, color, -webkit-box-shadow, -webkit-filter;
+        transition-property: background-color, border-color, color, box-shadow, filter;
+        transition-property: background-color, border-color, color, box-shadow, filter, -webkit-box-shadow, -webkit-filter;
+        -webkit-transition-duration: .3s;
+        transition-duration: .3s;
+        background-color: #FFFFFF !important;
+        color: #181818 !important;
+        height: 48px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 12px;
+        width: auto !important;
+        border: 1px solid #181818 !important;
+        max-width: 100% !important;
+        box-shadow: none !important;
+        margin-right: 15px !important;
+        margin-bottom: 32px !important;
+    }
+
+    #onetrust-pc-sdk #clear-filters-container {
+        display: none !important;
+    }
+
+    #onetrust-pc-sdk .ot-group-options {
+        margin-top: 32px;
+    }
+
+    #onetrust-pc-sdk #vendor-search-handler {
+        padding: 0 15px 0 35px !important;
+    }
+
+    #onetrust-pc-sdk #ot-triangle {
+        right: auto !important;
+        left: calc(100% - 64px) !important;
+        top: 64px !important;
+    }
+
+    #onetrust-pc-sdk #vendors-list .ot-arrow-container {
+        margin-top: 7px !important;
+    }
+
+    @media only screen and (max-width: 600px) {
+        #onetrust-pc-sdk #content {
+            padding: 0px !important;
+            margin: 0px !important;
+            width: calc(100% - 48px) !important;
+            padding-top: 48px !important;
+            padding-bottom: 30px !important;
+        }
+
+    }
+
+    @media only screen and (min-width: 576px) {
+        #onetrust-pc-sdk #ot-options {
+            left: 260px !important;
+            max-width: 310px !important;
+        }
+    }
+
+    @media only screen and (min-width: 768px) {
+        #onetrust-banner-sdk #onetrust-button-group {
+            flex-direction: row;
+            margin-top: 16px;
+        }
+
+        #onetrust-banner-sdk #onetrust-accept-btn-handler {
+            margin: 0 !important;
+        }
+
+        #onetrust-banner-sdk.ot-buttons-fw #onetrust-pc-btn-handler.cookie-setting-link {
+            padding: 0 !important;
+        }
+
+        #onetrust-consent-sdk #onetrust-pc-btn-handler.cookie-setting-link {
+            padding: 0;
+            margin: 0 40px;
+        }
+
+        #onetrust-banner-sdk .ot-sdk-columns {
+            margin: 0 !important;
+        }
+
+        #onetrust-button-group-parent {
+            padding: 0 !important;
+        }
+
+        #onetrust-banner-sdk #onetrust-policy-title {
+            font-size: 18px !important;
+        }
+
+        #onetrust-consent-sdk #onetrust-policy-text {
+            font-size: 14px !important;
+        }
+
+        #onetrust-banner-sdk .ot-dpd-title {
+            font-size: 14px !important;
+        }
+
+        #onetrust-banner-sdk .ot-dpd-desc {
+            font-size: 14px !important;
+        }
+
+        #onetrust-banner-sdk .onetrust-vendors-list-handler {
+            font-size: 14px !important;
+        }
+    }
+
+    @media only screen and (min-width: 1024px) {
+        #onetrust-banner-sdk .ot-dpd-title {
+            padding-top: 14px !important;
+        }
+
+        #onetrust-consent-sdk #onetrust-policy-text {
+            border: none !important;
+            width: calc(50% - 25px) !important;
+            padding-right: 50px !important;
+        }
+
+        #onetrust-banner-sdk .ot-dpd-container {
+            width: calc(45% - 25px) !important;
+        }
+    }
+
+    [data-optanongroupid=i00] {
+        display: none;
+    }
+
+    #onetrust-pc-sdk.otPcCenter {
+        position: fixed;
+        margin: 0 auto;
+        top: 5%;
+        bottom: 10%;
+        right: 0;
+        left: 0;
+        width: 40%;
+        max-width: 575px;
+        min-width: 575px;
+        border-radius: 2.5px;
+        z-index: 2147483647;
+        background-color: #fff;
+        -webkit-box-shadow: 0px 2px 10px -3px #999;
+        -moz-box-shadow: 0px 2px 10px -3px #999;
+        box-shadow: 0px 2px 10px -3px #999
+    }
+
+    #onetrust-pc-sdk.otRelFont {
+        font-size: 1rem
+    }
+
+    #onetrust-pc-sdk.otPcCenter[dir=rtl] {
+        right: 0;
+        left: 0
+    }
+
+    #onetrust-pc-sdk.ot-sdk-container {
+        padding: 0
+    }
+
+    #onetrust-pc-sdk #pc-title, #onetrust-pc-sdk #manage-cookies-text, #onetrust-pc-sdk .category-header, #onetrust-pc-sdk #vendors-list-title, #onetrust-pc-sdk #select-all-text-container p, #onetrust-pc-sdk .vendor-info .vendor-title, #onetrust-pc-sdk .ot-always-active {
+        font-weight: bold;
+        color: dimgray
+    }
+
+    #onetrust-pc-sdk .category-header {
+        float: left;
+        width: calc(100% - 65px)
+    }
+
+    #onetrust-pc-sdk .category-item p {
+        clear: both;
+        float: left;
+        margin-top: 10px;
+        margin-bottom: 5px;
+        line-height: 1.4;
+        font-size: .82em;
+        color: dimgray
+    }
+
+    #onetrust-pc-sdk .pc-close-button {
+        height: 44px;
+        width: 44px;
+        background-size: 10px
+    }
+
+    #onetrust-pc-sdk #pc-title {
+        float: left;
+        font-size: 1.2em;
+        line-height: 1.3;
+        margin-bottom: 10px;
+        width: 100%
+    }
+
+    #onetrust-pc-sdk #pc-policy-text {
+        clear: both;
+        width: 100%;
+        font-size: .82em;
+        line-height: 1.4
+    }
+
+    #onetrust-pc-sdk #pc-policy-text a {
+        font-size: 1em;
+        line-height: 1.2
+    }
+
+    #onetrust-pc-sdk #pc-policy-text * {
+        font-size: inherit
+    }
+
+    #onetrust-pc-sdk #pc-policy-text ul li {
+        padding: 10px 0px
+    }
+
+    #onetrust-pc-sdk #vdr-lst-dsc {
+        font-size: .812em;
+        line-height: 1.5;
+        padding: 10px 15px 5px 15px
+    }
+
+    #onetrust-pc-sdk a {
+        color: #656565;
+        cursor: pointer
+    }
+
+    #onetrust-pc-sdk a:hover {
+        color: #3860be
+    }
+
+    #onetrust-pc-sdk label {
+        margin-bottom: 0
+    }
+
+    #onetrust-pc-sdk .ot-link-btn {
+        padding: 0;
+        margin-bottom: 0;
+        border: 0;
+        font-weight: normal;
+        line-height: normal;
+        width: auto;
+        height: auto
+    }
+
+    #onetrust-pc-sdk button {
+        max-width: 394px;
+        padding: 12px 30px;
+        line-height: 1;
+        word-break: break-word;
+        word-wrap: break-word;
+        white-space: normal;
+        font-weight: bold;
+        height: auto
+    }
+
+    #onetrust-pc-sdk #ot-content {
+        position: absolute;
+        overflow-y: scroll;
+        padding-left: 0px;
+        padding-right: 30px;
+        top: 20px;
+        bottom: 20px;
+        margin: 0 3px 0 50px;
+        width: calc(100% - 83px)
+    }
+
+    #onetrust-pc-sdk #cookie-preferences .ot-always-active {
+        float: right;
+        clear: none;
+        color: #3860be;
+        margin: 0;
+        font-size: .9em;
+        line-height: 1.3
+    }
+
+    #onetrust-pc-sdk #ot-content::-webkit-scrollbar-track, #onetrust-pc-sdk .ot-group-options::-webkit-scrollbar-track, #onetrust-pc-sdk #vendor-list-content::-webkit-scrollbar-track {
+        margin-right: 20px
+    }
+
+    #onetrust-pc-sdk #ot-content::-webkit-scrollbar, #onetrust-pc-sdk .ot-group-options::-webkit-scrollbar, #onetrust-pc-sdk #vendor-list-content::-webkit-scrollbar {
+        width: 11px
+    }
+
+    #onetrust-pc-sdk #ot-content::-webkit-scrollbar-thumb, #onetrust-pc-sdk .ot-group-options::-webkit-scrollbar-thumb, #onetrust-pc-sdk #vendor-list-content::-webkit-scrollbar-thumb {
+        border-radius: 10px;
+        background: #d8d8d8
+    }
+
+    #onetrust-pc-sdk input[type=checkbox]:focus + .accordion-header {
+        outline-style: solid;
+        outline-width: 1px
+    }
+
+    #onetrust-pc-sdk #ot-content, #onetrust-pc-sdk #vendor-list-content, #onetrust-pc-sdk .ot-group-options {
+        scrollbar-arrow-color: #d8d8d8;
+        scrollbar-darkshadow-color: #d8d8d8;
+        scrollbar-face-color: #d8d8d8;
+        scrollbar-shadow-color: #d8d8d8
+    }
+
+    #onetrust-pc-sdk #accept-recommended-container {
+        margin-bottom: 10px
+    }
+
+    #onetrust-pc-sdk #accept-recommended-container button {
+        float: left;
+        outline-offset: -1px
+    }
+
+    #onetrust-pc-sdk .save-preference-btn-handler {
+        float: left
+    }
+
+    #onetrust-pc-sdk .ot-pc-refuse-all-handler {
+        float: left;
+        margin-right: 10px
+    }
+
+    #onetrust-pc-sdk #privacy-notice-link {
+        text-decoration: underline
+    }
+
+    #onetrust-pc-sdk .cookie-subgroups-container {
+        display: inline-block;
+        clear: both;
+        width: 100%;
+        margin-bottom: 10px
+    }
+
+    #onetrust-pc-sdk .cookie-subgroup-toggle {
+        float: right
+    }
+
+    #onetrust-pc-sdk .cookie-subgroup-toggle.ot-always-active-subgroup {
+        width: auto
+    }
+
+    #onetrust-pc-sdk ul.cookie-subgroups {
+        margin: 0;
+        font-size: initial
+    }
+
+    #onetrust-pc-sdk ul.cookie-subgroups li p, #onetrust-pc-sdk ul.cookie-subgroups li h5 {
+        font-size: .7em;
+        line-height: 1.4;
+        color: dimgray
+    }
+
+    #onetrust-pc-sdk ul.cookie-subgroups .ot-switch {
+        min-height: auto
+    }
+
+    #onetrust-pc-sdk ul.cookie-subgroups .ot-switch-nob {
+        top: 0
+    }
+
+    #onetrust-pc-sdk ul.cookie-subgroups .accordion-header {
+        display: inline-block;
+        width: 100%
+    }
+
+    #onetrust-pc-sdk ul.cookie-subgroups .accordion-text {
+        margin: 0
+    }
+
+    #onetrust-pc-sdk ul.cookie-subgroups li {
+        padding: 0;
+        border: none
+    }
+
+    #onetrust-pc-sdk ul.cookie-subgroups li h5 {
+        position: relative;
+        top: 5px;
+        font-weight: bold;
+        margin-bottom: 0;
+        float: left
+    }
+
+    #onetrust-pc-sdk li.cookie-subgroup {
+        margin-left: 20px;
+        overflow: auto
+    }
+
+    #onetrust-pc-sdk li.cookie-subgroup > h5 {
+        width: calc(100% - 70px)
+    }
+
+    #onetrust-pc-sdk .category-item p > ul, #onetrust-pc-sdk li.cookie-subgroup p > ul {
+        margin: 0px;
+        list-style: disc;
+        margin-left: 15px;
+        font-size: inherit
+    }
+
+    #onetrust-pc-sdk .category-item p > ul li, #onetrust-pc-sdk li.cookie-subgroup p > ul li {
+        font-size: inherit;
+        padding-top: 10px;
+        padding-left: 0px;
+        padding-right: 0px;
+        border: none
+    }
+
+    #onetrust-pc-sdk .category-item p > ul li:last-child, #onetrust-pc-sdk li.cookie-subgroup p > ul li:last-child {
+        padding-bottom: 10px
+    }
+
+    #onetrust-pc-sdk .ot-switch.ot-hide-tgl {
+        visibility: hidden
+    }
+
+    #onetrust-pc-sdk .ot-switch.ot-hide-tgl * {
+        visibility: hidden
+    }
+
+    #onetrust-pc-sdk .pc-logo {
+        height: 40px;
+        width: 120px;
+        margin-bottom: 10px
+    }
+
+    #onetrust-pc-sdk .ot-pc-footer-logo {
+        height: 25px;
+        width: 138px;
+        float: right;
+        margin-top: 31px
+    }
+
+    #onetrust-pc-sdk.otPcCenter[dir=rtl] .ot-pc-footer-logo {
+        direction: rtl
+    }
+
+    #onetrust-pc-sdk .ot-toggle-group, #onetrust-pc-sdk .ot-toggle, #onetrust-pc-sdk .ot-arrow-container {
+        display: inline-block
+    }
+
+    #onetrust-pc-sdk .ot-toggle-group {
+        width: 70px;
+        float: right
+    }
+
+    #onetrust-pc-sdk .ot-toggle {
+        padding: 0;
+        font-size: 100%
+    }
+
+    #onetrust-pc-sdk .ot-arrow {
+        width: 10px;
+        margin-left: 15px
+    }
+
+    #onetrust-pc-sdk button.ot-pill {
+        border-radius: 20px;
+        font-size: .75em;
+        text-align: center;
+        background-color: #3860be;
+        border-color: #3860be;
+        font-weight: 600;
+        box-shadow: 0 0 10px 1px #cce1ff;
+        width: 180px;
+        color: #fff;
+        height: auto;
+        white-space: normal;
+        word-break: break-word;
+        word-wrap: break-word;
+        padding: 10px;
+        line-height: 1.2;
+        letter-spacing: .05em
+    }
+
+    #onetrust-pc-sdk button.ot-pill:first-child {
+        margin-top: 10px
+    }
+
+    #onetrust-pc-sdk .ot-arrow-container {
+        margin-top: 1.2px
+    }
+
+    #onetrust-pc-sdk .ot-arrow-container svg {
+        -webkit-transition: all 300ms ease-in 0s;
+        -moz-transition: all 300ms ease-in 0s;
+        -o-transition: all 300ms ease-in 0s;
+        transition: all 300ms ease-in 0s;
+        height: 10px;
+        width: 10px
+    }
+
+    #onetrust-pc-sdk input:checked ~ .accordion-header .ot-arrow {
+        transform: rotate(90deg);
+        -o-transform: rotate(90deg);
+        -ms-transform: rotate(90deg);
+        -webkit-transform: rotate(90deg)
+    }
+
+    #onetrust-pc-sdk .ot-arrow {
+        width: 10px;
+        margin-left: 15px;
+        transition: all 300ms ease-in 0s;
+        -webkit-transition: all 300ms ease-in 0s;
+        -moz-transition: all 300ms ease-in 0s;
+        -o-transition: all 300ms ease-in 0s
+    }
+
+    #onetrust-pc-sdk .category-vendors-list-container {
+        margin-bottom: 0
+    }
+
+    #onetrust-pc-sdk .category-host-list-container {
+        margin-top: 10px
+    }
+
+    #onetrust-pc-sdk .category-vendors-list-handler, #onetrust-pc-sdk .category-vendors-list-handler + a, #onetrust-pc-sdk .category-host-list-handler {
+        clear: both;
+        color: #3860be;
+        margin-left: 0;
+        font-size: .75em;
+        text-decoration: none;
+        float: left
+    }
+
+    #onetrust-pc-sdk .category-vendors-list-handler:hover, #onetrust-pc-sdk .category-vendors-list-handler + a:hover, #onetrust-pc-sdk .category-host-list-handler:hover {
+        color: #1883fd
+    }
+
+    #onetrust-pc-sdk .category-vendors-list-handler + a {
+        clear: none
+    }
+
+    #onetrust-pc-sdk .category-vendors-list-handler + a::after {
+        content: "";
+        height: 15px;
+        width: 15px;
+        background-repeat: no-repeat;
+        margin-left: 5px;
+        float: right;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 511.626 511.627'%3E%3Cg fill='%231276CE'%3E%3Cpath d='M392.857 292.354h-18.274c-2.669 0-4.859.855-6.563 2.573-1.718 1.708-2.573 3.897-2.573 6.563v91.361c0 12.563-4.47 23.315-13.415 32.262-8.945 8.945-19.701 13.414-32.264 13.414H82.224c-12.562 0-23.317-4.469-32.264-13.414-8.945-8.946-13.417-19.698-13.417-32.262V155.31c0-12.562 4.471-23.313 13.417-32.259 8.947-8.947 19.702-13.418 32.264-13.418h200.994c2.669 0 4.859-.859 6.57-2.57 1.711-1.713 2.566-3.9 2.566-6.567V82.221c0-2.662-.855-4.853-2.566-6.563-1.711-1.713-3.901-2.568-6.57-2.568H82.224c-22.648 0-42.016 8.042-58.102 24.125C8.042 113.297 0 132.665 0 155.313v237.542c0 22.647 8.042 42.018 24.123 58.095 16.086 16.084 35.454 24.13 58.102 24.13h237.543c22.647 0 42.017-8.046 58.101-24.13 16.085-16.077 24.127-35.447 24.127-58.095v-91.358c0-2.669-.856-4.859-2.574-6.57-1.713-1.718-3.903-2.573-6.565-2.573z'/%3E%3Cpath d='M506.199 41.971c-3.617-3.617-7.905-5.424-12.85-5.424H347.171c-4.948 0-9.233 1.807-12.847 5.424-3.617 3.615-5.428 7.898-5.428 12.847s1.811 9.233 5.428 12.85l50.247 50.248-186.147 186.151c-1.906 1.903-2.856 4.093-2.856 6.563 0 2.479.953 4.668 2.856 6.571l32.548 32.544c1.903 1.903 4.093 2.852 6.567 2.852s4.665-.948 6.567-2.852l186.148-186.148 50.251 50.248c3.614 3.617 7.898 5.426 12.847 5.426s9.233-1.809 12.851-5.426c3.617-3.616 5.424-7.898 5.424-12.847V54.818c-.001-4.952-1.814-9.232-5.428-12.847z'/%3E%3C/g%3E%3C/svg%3E")
+    }
+
+    #onetrust-pc-sdk .back-btn-handler {
+        font-size: 1em;
+        text-decoration: none;
+        font-weight: bold;
+        color: #2e3644;
+        display: table-cell;
+        vertical-align: middle
+    }
+
+    #onetrust-pc-sdk .back-btn-handler p {
+        display: inline-block;
+        word-break: break-word;
+        word-wrap: break-word;
+        margin-bottom: 0;
+        max-width: 70px;
+        vertical-align: middle;
+        color: #656565;
+        font-size: .8em;
+        font-weight: bold
+    }
+
+    #onetrust-pc-sdk .back-btn-handler p:hover {
+        opacity: .6
+    }
+
+    #onetrust-pc-sdk #vendors-list-title {
+        margin: 30px 0 15px 20px;
+        font-size: 1em;
+        text-align: left
+    }
+
+    #onetrust-pc-sdk #vendors-list-header {
+        margin: 20px 0 0 30px;
+        height: auto;
+        width: auto
+    }
+
+    #onetrust-pc-sdk #vendors-list-header input::placeholder {
+        color: #d4d4d4;
+        font-style: italic
+    }
+
+    #onetrust-pc-sdk #vendor-search-handler {
+        height: 31px;
+        width: 380px;
+        border-radius: 50px;
+        font-size: .8em;
+        padding: 0 35px 0 15px;
+        float: left;
+        margin: 6px 12px 0 50px
+    }
+
+    #onetrust-pc-sdk #vendor-list-content {
+        position: relative;
+        overflow-y: scroll;
+        padding-left: 0px;
+        top: 60px;
+        bottom: 75px;
+        margin-right: 7px;
+        margin-left: 40px;
+        max-width: 90%;
+        min-width: 90%;
+        height: calc(100% - 265px)
+    }
+
+    #onetrust-pc-sdk #vendor-list-content .ot-sdk-column {
+        padding-right: 22px;
+        padding-left: 10px
+    }
+
+    #onetrust-pc-sdk #vendor-list-content.no-results {
+        height: calc(100% - 300px)
+    }
+
+    #onetrust-pc-sdk #vendors-list {
+        height: calc(100% - 12px);
+        width: 100%;
+        bottom: 0px
+    }
+
+    #onetrust-pc-sdk #vendors-list .ot-toggle-group {
+        top: 10px;
+        width: 50px;
+        right: 12px;
+        position: absolute
+    }
+
+    #onetrust-pc-sdk #vendors-list .ot-checkbox {
+        height: auto
+    }
+
+    #onetrust-pc-sdk #vendors-list .ot-arrow-container {
+        float: right;
+        position: relative
+    }
+
+    #onetrust-pc-sdk .category-vendors-list-container {
+        overflow: hidden
+    }
+
+    #onetrust-pc-sdk #select-all-container {
+        position: relative;
+        height: auto;
+        width: 100%;
+        display: block;
+        top: 43px;
+        margin-bottom: 10px;
+        padding-bottom: 4px;
+        color: dimgray
+    }
+
+    #onetrust-pc-sdk #select-all-container p {
+        font-size: .75em;
+        color: #6b6b6b;
+        margin: 0;
+        display: inline-block
+    }
+
+    #onetrust-pc-sdk #select-all-container .ot-checkbox {
+        height: auto;
+        float: right;
+        width: 160px;
+        max-width: 160px;
+        margin-right: 90px
+    }
+
+    #onetrust-pc-sdk.ot-sdk-not-webkit #select-all-container .ot-checkbox {
+        margin-right: 99px
+    }
+
+    #onetrust-pc-sdk #ot-back-arrow {
+        height: 12px;
+        width: 20px;
+        display: inline-block;
+        vertical-align: middle
+    }
+
+    #onetrust-pc-sdk #search-container {
+        width: 100%;
+        left: 0;
+        position: absolute;
+        height: 45px;
+        background-color: #f8f8f8
+    }
+
+    #onetrust-pc-sdk #search-container > svg {
+        width: 30px;
+        height: 30px;
+        position: relative;
+        float: left;
+        right: 42px;
+        top: 6px
+    }
+
+    #onetrust-pc-sdk #filter-btn-handler {
+        border-radius: 17px;
+        display: inline-block;
+        position: relative;
+        width: 32px;
+        height: 32px;
+        margin-top: 6px;
+        right: 25px;
+        -moz-transition: .1s ease;
+        -o-transition: .1s ease;
+        -webkit-transition: 1s ease;
+        transition: .1s ease
+    }
+
+    #onetrust-pc-sdk #filter-btn-handler span {
+        margin-bottom: 0;
+        line-height: 1.2;
+        font-size: 1em;
+        color: #2e3644;
+        max-width: 100px;
+        vertical-align: middle
+    }
+
+    #onetrust-pc-sdk #filter-icon {
+        width: 12px;
+        height: 30px;
+        margin: 3px 10px 0 10px;
+        display: block;
+        position: static;
+        right: auto;
+        top: auto
+    }
+
+    #onetrust-pc-sdk #filter-btn-handler:hover {
+        background-color: #3860be
+    }
+
+    #onetrust-pc-sdk #filter-btn-handler:hover #filter-icon-path {
+        fill: #fff
+    }
+
+    #onetrust-pc-sdk .vendor-privacy-notice {
+        color: #3860be;
+        text-decoration: none;
+        font-weight: 100;
+        display: block;
+        padding-top: 10px;
+        transform: translate(0, 1%);
+        -o-transform: translate(0, 1%);
+        -ms-transform: translate(0, 1%);
+        -webkit-transform: translate(0, 1%);
+        position: relative;
+        z-index: 2
+    }
+
+    #onetrust-pc-sdk .vendor-privacy-notice * {
+        font-size: inherit
+    }
+
+    #onetrust-pc-sdk .vendor-privacy-notice:hover {
+        text-decoration: underline
+    }
+
+    #onetrust-pc-sdk .vendor-title {
+        width: 130px;
+        max-width: 130px;
+        vertical-align: middle
+    }
+
+    #onetrust-pc-sdk .vendor-info {
+        width: 120px;
+        height: auto;
+        float: left;
+        word-break: break-word;
+        word-wrap: break-word;
+        vertical-align: middle;
+        padding-left: 3px;
+        padding-bottom: 3px
+    }
+
+    #onetrust-pc-sdk .vendor-purposes {
+        transform: translate(150%, 150%);
+        -o-transform: translate(150%, 150%);
+        -ms-transform: translate(150%, 150%);
+        -webkit-transform: translate(150%, 150%);
+        vertical-align: bottom;
+        height: auto;
+        float: left;
+        text-align: center
+    }
+
+    #onetrust-pc-sdk .vendor-purposes p {
+        margin-bottom: 0;
+        font-weight: 500;
+        float: left;
+        word-break: break-word;
+        word-wrap: break-word
+    }
+
+    #onetrust-pc-sdk .vendor-purposes p, #onetrust-pc-sdk .vendor-privacy-notice {
+        letter-spacing: .03em;
+        font-size: .7em;
+        font-weight: 400
+    }
+
+    #onetrust-pc-sdk .vendor-options {
+        min-height: 100px;
+        border-radius: 2px;
+        background-color: #f8f8f8
+    }
+
+    #onetrust-pc-sdk .vendor-options:first-child {
+        border-top: none
+    }
+
+    #onetrust-pc-sdk .vendor-option:first-of-type {
+        border-top: none
+    }
+
+    #onetrust-pc-sdk .vendor-option {
+        min-height: 30px;
+        display: table;
+        width: 100%;
+        border-top: 1px solid #e2e2e2
+    }
+
+    #onetrust-pc-sdk .vendor-option a {
+        display: table-cell;
+        vertical-align: middle;
+        width: 120px
+    }
+
+    #onetrust-pc-sdk .vendor-option a span {
+        font-size: .75em;
+        color: #3860be;
+        width: 100px
+    }
+
+    #onetrust-pc-sdk .vendor-option a svg {
+        width: 18px;
+        vertical-align: bottom
+    }
+
+    #onetrust-pc-sdk .vendor-option p {
+        display: table-cell;
+        vertical-align: middle;
+        word-break: break-word;
+        word-wrap: break-word;
+        margin: 0;
+        padding: 0 0 0 15px;
+        width: 150px;
+        font-size: .75em;
+        line-height: 1.4;
+        color: #2e3644
+    }
+
+    #onetrust-pc-sdk #vendors-list-container .accordion-header {
+        overflow: hidden;
+        cursor: pointer
+    }
+
+    #onetrust-pc-sdk .vendor-options {
+        border-radius: 2px
+    }
+
+    #onetrust-pc-sdk .vendor-options p {
+        font-size: .69em;
+        text-align: left;
+        display: table-cell;
+        vertical-align: middle;
+        word-break: break-word;
+        word-wrap: break-word;
+        margin: 0;
+        padding-left: 15px;
+        color: #2e3644
+    }
+
+    #onetrust-pc-sdk #vendor-list-content.host-list-content {
+        margin-left: 30px;
+        margin-right: 7px
+    }
+
+    #onetrust-pc-sdk #vendor-list-content.host-list-content .ot-sdk-column {
+        padding: 0px
+    }
+
+    #onetrust-pc-sdk #vendor-list-content.host-list-content + #vendor-list-save-btn {
+        padding-left: 30px
+    }
+
+    #onetrust-pc-sdk .hosts-list #vendors-list-header {
+        margin-left: 0px
+    }
+
+    #onetrust-pc-sdk .hosts-list .back-btn-handler {
+        padding-left: 12px
+    }
+
+    #onetrust-pc-sdk .hosts-list #vendors-list-title {
+        margin-left: 30px
+    }
+
+    #onetrust-pc-sdk .hosts-list #vendor-search-handler {
+        margin-left: 30px
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .ot-checkbox {
+        float: right;
+        position: relative;
+        margin-right: 42px;
+        top: 10px
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .ot-checkbox input[type=checkbox] {
+        width: auto;
+        height: auto
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .ot-checkbox label {
+        height: 20px;
+        width: 20px;
+        padding-left: 0px
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .accordion-header {
+        display: inline-block;
+        width: 100%
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .accordion-text {
+        overflow: hidden;
+        width: 95%
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-info {
+        width: 85%;
+        float: left
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-title, #onetrust-pc-sdk #hosts-list-container .host-description {
+        display: inline-block;
+        width: 90%
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-info > a {
+        text-decoration: underline;
+        font-size: .82em;
+        position: relative;
+        z-index: 2;
+        float: left;
+        margin-bottom: 5px
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-title + a {
+        margin-top: 5px
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-notice {
+        margin-top: 3px;
+        clear: both
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-title, #onetrust-pc-sdk #hosts-list-container .host-title a, #onetrust-pc-sdk #hosts-list-container .host-description, #onetrust-pc-sdk #hosts-list-container .vendor-host {
+        color: dimgray;
+        word-break: break-word;
+        word-wrap: break-word
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-title, #onetrust-pc-sdk #hosts-list-container .host-title a {
+        font-weight: bold;
+        font-size: .82em;
+        line-height: 1.3
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-title a, #onetrust-pc-sdk #hosts-list-container .cookie-name-container a {
+        font-size: 1em
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-notice span {
+        color: #3860be;
+        font-size: .72em;
+        font-weight: normal;
+        display: inline-block
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-notice span * {
+        font-size: inherit
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-description, #onetrust-pc-sdk #hosts-list-container .vendor-host {
+        font-size: .688em;
+        line-height: 1.4;
+        font-weight: normal
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-description {
+        margin-top: 10px
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-item {
+        padding: 10px 0px;
+        overflow: auto
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-item:first-of-type {
+        border-top: 1px solid #e2e2e2
+    }
+
+    #onetrust-pc-sdk #hosts-list-container input:checked ~ .accordion-header .ot-arrow-container {
+        border-left: 6px solid transparent;
+        border-right: 6px solid transparent;
+        border-top: 6px solid #737373;
+        margin-top: 6px
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .ot-arrow-container {
+        float: none;
+        display: inline-block;
+        vertical-align: middle;
+        border-top: 6px solid transparent;
+        border-bottom: 6px solid transparent;
+        border-left: 6px solid #737373;
+        margin-left: 10px
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-option-group {
+        margin: 0;
+        font-size: inherit;
+        display: inline-block;
+        width: 100%
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-option-group li > div div {
+        font-size: .8em;
+        padding: 5px 0
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-option-group li > div div:nth-child(1) {
+        width: 30%;
+        float: left
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .host-option-group li > div div:nth-child(2) {
+        width: 70%;
+        float: left;
+        word-break: break-word;
+        word-wrap: break-word
+    }
+
+    #onetrust-pc-sdk #hosts-list-container .vendor-host {
+        border: none;
+        display: inline-block;
+        width: calc(100% - 10px);
+        padding: 10px;
+        margin-bottom: 10px;
+        background-color: #f8f8f8
+    }
+
+    #onetrust-pc-sdk .vendor-option-purpose {
+        border-top: 1px solid #e9e9e9;
+        border-bottom: 1px solid #e9e9e9;
+        margin-bottom: 10px;
+        min-height: 30px;
+        max-height: 50px;
+        width: 100%;
+        display: table
+    }
+
+    #onetrust-pc-sdk .vendor-option-purpose:first-child, #onetrust-pc-sdk .vendor-option-purpose:first-of-type {
+        border-top: none
+    }
+
+    #onetrust-pc-sdk .vendor-option-purpose p {
+        font-weight: bold
+    }
+
+    #onetrust-pc-sdk .vendor-consent-group {
+        display: inline-block;
+        width: calc(100% - 15px);
+        margin-bottom: 10px
+    }
+
+    #onetrust-pc-sdk .ot-ven-disc {
+        padding-bottom: 10px
+    }
+
+    #onetrust-pc-sdk .ot-ven-disc:not(:first-child) {
+        border-top: 1px solid #e9e9e9
+    }
+
+    #onetrust-pc-sdk .ot-ven-disc:nth-child(n+3) p {
+        display: inline-block
+    }
+
+    #onetrust-pc-sdk .ot-ven-disc:nth-child(n+3) p:nth-of-type(odd) {
+        width: 30%
+    }
+
+    #onetrust-pc-sdk .ot-ven-disc:nth-child(n+3) p:nth-of-type(even) {
+        width: 50%;
+        word-break: break-word;
+        word-wrap: break-word
+    }
+
+    #onetrust-pc-sdk .ot-ven-disc p {
+        padding-top: 10px;
+        display: block
+    }
+
+    #onetrust-pc-sdk .legitimate-interest-group .consent-category {
+        float: left
+    }
+
+    #onetrust-pc-sdk .vendor-opt-out-handler {
+        text-decoration: none;
+        float: right;
+        color: #3860be;
+        position: relative
+    }
+
+    #onetrust-pc-sdk .vendor-opt-out-handler span {
+        font-size: .69em;
+        line-height: 1.4
+    }
+
+    #onetrust-pc-sdk .vendor-opt-out-handler svg {
+        width: 15px;
+        height: 15px;
+        vertical-align: middle
+    }
+
+    #onetrust-pc-sdk #no-results {
+        text-align: center;
+        margin-top: 30px;
+        max-width: 93%
+    }
+
+    #onetrust-pc-sdk #no-results p {
+        font-size: 1em;
+        color: #2e3644;
+        word-break: break-word;
+        word-wrap: break-word
+    }
+
+    #onetrust-pc-sdk #no-results p span {
+        font-weight: bold
+    }
+
+    #onetrust-pc-sdk #ot-filter-modal {
+        width: 100%;
+        height: auto;
+        display: none;
+        -moz-transition: .2s ease;
+        -o-transition: .2s ease;
+        -webkit-transition: 2s ease;
+        transition: .2s ease;
+        overflow: hidden;
+        opacity: 1;
+        right: 0
+    }
+
+    #onetrust-pc-sdk #ot-filter-modal .ot-pill {
+        width: 130px;
+        float: right;
+        margin-top: 10px
+    }
+
+    #onetrust-pc-sdk #ot-options {
+        z-index: 2147483646;
+        background-color: #fff;
+        position: absolute;
+        height: auto;
+        max-width: 325px;
+        max-height: 450px;
+        left: 195px;
+        margin-top: 14px;
+        margin-bottom: 20px;
+        padding-right: 10px;
+        border-radius: 3px;
+        -webkit-box-shadow: 0px 0px 12px 2px #c7c5c7;
+        -moz-box-shadow: 0px 0px 12px 2px #c7c5c7;
+        box-shadow: 0px 0px 12px 2px #c7c5c7
+    }
+
+    #onetrust-pc-sdk .ot-group-options {
+        max-height: 325px;
+        overflow-y: auto;
+        width: 100%
+    }
+
+    #onetrust-pc-sdk #ot-triangle {
+        border: 12px solid transparent;
+        display: none;
+        position: absolute;
+        z-index: 2147483647;
+        right: 100px;
+        top: 48px;
+        transform: rotate(45deg);
+        -o-transform: rotate(45deg);
+        -ms-transform: rotate(45deg);
+        -webkit-transform: rotate(45deg);
+        background-color: #fff;
+        -webkit-box-shadow: -3px -3px 5px -2px #c7c5c7;
+        -moz-box-shadow: -3px -3px 5px -2px #c7c5c7;
+        box-shadow: -3px -3px 5px -2px #c7c5c7
+    }
+
+    #onetrust-pc-sdk .ot-group-option {
+        margin-bottom: 25px;
+        margin-left: 15px;
+        width: 75%
+    }
+
+    #onetrust-pc-sdk .ot-group-option p {
+        display: inline-block;
+        margin: 0;
+        font-size: .9em;
+        color: #2e3644
+    }
+
+    #onetrust-pc-sdk .ot-checkbox input[type=checkbox] {
+        opacity: 0;
+        margin: 0;
+        position: absolute
+    }
+
+    #onetrust-pc-sdk .ot-checkbox label {
+        position: relative;
+        display: inline-block;
+        padding-left: 30px;
+        cursor: pointer;
+        font-weight: 500
+    }
+
+    #onetrust-pc-sdk .ot-checkbox label span {
+        font-size: .85em;
+        color: dimgray
+    }
+
+    #onetrust-pc-sdk .ot-checkbox input:checked ~ label::before {
+        background-color: #3860be
+    }
+
+    #onetrust-pc-sdk .ot-checkbox label::before, #onetrust-pc-sdk .ot-checkbox label::after {
+        position: absolute;
+        content: "";
+        display: inline-block;
+        border-radius: 3px
+    }
+
+    #onetrust-pc-sdk .ot-checkbox label::before {
+        height: 18px;
+        width: 18px;
+        border: 1px solid #3860be;
+        left: 0px;
+        top: 2px
+    }
+
+    #onetrust-pc-sdk .ot-checkbox label::after {
+        height: 5px;
+        width: 9px;
+        border-left: 3px solid;
+        border-bottom: 3px solid;
+        transform: rotate(-45deg);
+        -o-transform: rotate(-45deg);
+        -ms-transform: rotate(-45deg);
+        -webkit-transform: rotate(-45deg);
+        left: 4px;
+        top: 7px
+    }
+
+    #onetrust-pc-sdk .ot-checkbox input[type=checkbox] + label::after {
+        content: none;
+        color: #fff
+    }
+
+    #onetrust-pc-sdk .ot-checkbox input[type=checkbox]:checked + label::after {
+        content: ""
+    }
+
+    #onetrust-pc-sdk .ot-checkbox input[type=checkbox]:focus + label::before {
+        outline-style: solid;
+        outline-width: 2px;
+        outline-style: auto
+    }
+
+    #onetrust-pc-sdk #select-all-text-container {
+        height: auto;
+        float: left;
+        width: 83%
+    }
+
+    #onetrust-pc-sdk #select-all-text-container p * {
+        font-size: inherit
+    }
+
+    #onetrust-pc-sdk #select-all-vendors-input-container, #onetrust-pc-sdk #select-all-hosts-input-container {
+        width: 21px;
+        height: auto;
+        float: right
+    }
+
+    #onetrust-pc-sdk #select-all-vendors-input-container label, #onetrust-pc-sdk #select-all-hosts-input-container label {
+        float: left;
+        padding-left: 0
+    }
+
+    #onetrust-pc-sdk #select-all-vendors-input-container .ot-group-option-box, #onetrust-pc-sdk #select-all-hosts-input-container .ot-group-option-box {
+        margin: 0
+    }
+
+    #onetrust-pc-sdk .label-text {
+        display: none
+    }
+
+    #onetrust-pc-sdk #vendors-list-container:first-child {
+        border-top: 1px solid #e2e2e2
+    }
+
+    #onetrust-pc-sdk ul {
+        list-style: none;
+        padding: 0
+    }
+
+    #onetrust-pc-sdk ul li {
+        position: relative;
+        margin: 0;
+        padding: 15px 15px 15px 10px;
+        border-bottom: 1px solid #e2e2e2
+    }
+
+    #onetrust-pc-sdk ul li h3 {
+        font-size: .75em;
+        color: #656565;
+        margin: 0;
+        display: inline-block;
+        width: 70%;
+        height: auto;
+        word-break: break-word;
+        word-wrap: break-word
+    }
+
+    #onetrust-pc-sdk ul li p {
+        margin: 0;
+        font-size: .7em
+    }
+
+    #onetrust-pc-sdk ul li input[type=checkbox] {
+        position: absolute;
+        cursor: pointer;
+        width: 100%;
+        height: 100%;
+        opacity: 0;
+        margin: 0;
+        top: 0;
+        left: 0
+    }
+
+    #onetrust-pc-sdk ul li input[type=checkbox]:not(:checked) ~ .accordion-text {
+        margin-top: 0;
+        max-height: 0;
+        opacity: 0;
+        overflow: hidden;
+        width: 100%;
+        transition: .25s ease-out;
+        display: none
+    }
+
+    #onetrust-pc-sdk ul li input[type=checkbox]:checked ~ .accordion-text {
+        transition: .1s ease-in;
+        margin-top: 10px;
+        width: 100%;
+        display: block
+    }
+
+    #onetrust-pc-sdk .category-vendors-list-container {
+        margin-bottom: 0;
+        width: 100%
+    }
+
+    #onetrust-pc-sdk .category-vendors-list-handler, #onetrust-pc-sdk .category-vendors-list-handler + a {
+        margin-left: 0;
+        margin-top: 10px
+    }
+
+    #onetrust-pc-sdk .vendor-option .op-out-group {
+        float: right;
+        margin-right: 10px
+    }
+
+    #onetrust-pc-sdk #select-all-vendors-input-container.line-through label::after, #onetrust-pc-sdk #select-all-vendors-leg-input-container.line-through label::after, #onetrust-pc-sdk #select-all-hosts-input-container.line-through label::after {
+        height: auto;
+        border-left: 0;
+        transform: none;
+        -o-transform: none;
+        -ms-transform: none;
+        -webkit-transform: none;
+        left: 5px;
+        top: 10.5px
+    }
+
+    #onetrust-pc-sdk #vendor-list-save-btn {
+        position: relative;
+        top: 38px;
+        max-width: 90%;
+        padding-left: 50px;
+        padding-right: 50px
+    }
+
+    #onetrust-pc-sdk #manage-cookies-text {
+        float: left;
+        font-size: 1.2em;
+        width: 100%
+    }
+
+    #onetrust-pc-sdk .button-theme {
+        background-color: #68b631;
+        color: #fff;
+        border-color: #68b631;
+        font-size: .75em;
+        letter-spacing: .08em;
+        margin-top: 19px
+    }
+
+    #onetrust-pc-sdk .button-theme:hover, #onetrust-pc-sdk .button-theme:focus {
+        color: #fff;
+        border-color: #68b631
+    }
+
+    #onetrust-pc-sdk #cookie-preferences {
+        margin-top: 10px
+    }
+
+    #onetrust-pc-sdk #cookie-preferences h4 {
+        font-size: .9em;
+        line-height: 1.3;
+        max-width: 90%;
+        vertical-align: middle
+    }
+
+    #onetrust-pc-sdk .accordion-text .ot-switch, #onetrust-pc-sdk .ot-accordion-layout.category-item .ot-switch {
+        position: relative;
+        float: right;
+        width: 45px;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none
+    }
+
+    #onetrust-pc-sdk .accordion-text .switch-checkbox, #onetrust-pc-sdk .ot-accordion-layout.category-item .switch-checkbox {
+        opacity: 0
+    }
+
+    #onetrust-pc-sdk .accordion-text .ot-switch-label, #onetrust-pc-sdk .ot-accordion-layout.category-item .ot-switch-label {
+        display: block;
+        overflow: hidden;
+        cursor: pointer;
+        border: 1px solid #ddd;
+        border-radius: 20px;
+        background-color: #f2f1f1
+    }
+
+    #onetrust-pc-sdk .accordion-text .ot-switch-inner, #onetrust-pc-sdk .ot-accordion-layout.category-item .ot-switch-inner {
+        display: block;
+        width: 200%;
+        margin-left: -100%;
+        transition: margin .2s ease-in 0s;
+        -moz-transition: margin .2s ease-in 0s;
+        -o-transition: margin .2s ease-in 0s;
+        -webkit-transition: margin .2s ease-in 0s
+    }
+
+    #onetrust-pc-sdk .category-item {
+        line-height: 1.1;
+        margin-top: 10px;
+        display: inline-block;
+        width: 100%
+    }
+
+    #onetrust-pc-sdk .category-item .ot-switch-nob {
+        width: 17px;
+        height: 17px;
+        right: 20px
+    }
+
+    #onetrust-pc-sdk .category-item .ot-switch.ot-toggle input {
+        display: block;
+        position: absolute
+    }
+
+    #onetrust-pc-sdk .category-item .ot-switch.ot-toggle input:focus + .ot-switch-label {
+        outline-style: solid !important;
+        outline-width: 1px !important
+    }
+
+    #onetrust-pc-sdk .switch-checkbox.category-switch-handler {
+        margin: 0;
+        width: 0
+    }
+
+    #onetrust-pc-sdk .save-preference-btn-container {
+        margin-top: 20px;
+        position: relative
+    }
+
+    #onetrust-pc-sdk #close-pc-btn-handler.ot-close-icon, #onetrust-pc-sdk #vendor-close-pc-btn-handler.ot-close-icon {
+        position: absolute;
+        top: 15px;
+        right: 0;
+        z-index: 2;
+        padding: 0;
+        background-color: transparent;
+        border: none
+    }
+
+    #onetrust-pc-sdk #close-pc-btn-handler.ot-close-icon:hover, #onetrust-pc-sdk #vendor-close-pc-btn-handler.ot-close-icon:hover {
+        opacity: .7
+    }
+
+    #onetrust-pc-sdk #close-pc-btn-handler.ot-close-icon svg, #onetrust-pc-sdk #vendor-close-pc-btn-handler.ot-close-icon svg {
+        display: block;
+        height: 10px;
+        width: 10px
+    }
+
+    #onetrust-pc-sdk .ot-switch-inner:before, #onetrust-pc-sdk .ot-switch-inner:after {
+        display: block;
+        width: 50%;
+        height: 23px
+    }
+
+    #onetrust-pc-sdk .ot-switch-inner:before {
+        content: "";
+        background-color: #d5e9ff
+    }
+
+    #onetrust-pc-sdk .ot-switch-nob {
+        display: block;
+        margin: 2px;
+        background: #7d7d7d;
+        position: absolute;
+        bottom: 0;
+        border: 2px solid #7d7d7d;
+        border-radius: 20px;
+        transition: all .2s ease-in 0s;
+        -moz-transition: all .2s ease-in 0s;
+        -o-transition: all .2s ease-in 0s;
+        -webkit-transition: all .2s ease-in 0s
+    }
+
+    #onetrust-pc-sdk .switch-checkbox:checked + .ot-switch-label {
+        transition: all .2s ease-in 0s;
+        -moz-transition: all .2s ease-in 0s;
+        -o-transition: all .2s ease-in 0s;
+        -webkit-transition: all .2s ease-in 0s;
+        border: 1px solid #3860be
+    }
+
+    #onetrust-pc-sdk .switch-checkbox:checked + .ot-switch-label .ot-switch-inner {
+        margin-left: 0
+    }
+
+    #onetrust-pc-sdk .switch-checkbox:checked + .ot-switch-label .ot-switch-nob {
+        right: 0px;
+        background-color: #3860be;
+        border-color: #3860be
+    }
+
+    #onetrust-pc-sdk #clear-filters-handler {
+        float: right;
+        max-width: 200px;
+        margin-bottom: 30px;
+        text-decoration: none
+    }
+
+    #onetrust-pc-sdk #clear-filters-handler p {
+        float: right;
+        font-weight: bold;
+        color: #3860be;
+        font-size: .9em;
+        margin: 0
+    }
+
+    #onetrust-pc-sdk #clear-filters-handler p:hover {
+        color: #2285f7
+    }
+
+    #onetrust-pc-sdk #clear-filters-container {
+        width: 100%;
+        height: auto;
+        margin-top: 20px;
+        float: right
+    }
+
+    #onetrust-pc-sdk .category-switch-handler:not(:checked), #onetrust-pc-sdk .category-switch-handler:checked {
+        position: initial;
+        pointer-events: initial
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout.category-item {
+        position: relative;
+        border-radius: 2px;
+        margin: 0;
+        padding: 0;
+        border: 1px solid #e9e9e9;
+        border-top: none;
+        width: calc(100% - 2px);
+        float: left
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout.category-item:first-of-type {
+        margin-top: 10px;
+        border-top: 1px solid #e9e9e9
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout.category-item > input[type=checkbox] {
+        position: absolute;
+        cursor: pointer;
+        width: 100%;
+        height: 100%;
+        opacity: 0;
+        margin: 0;
+        top: 0;
+        left: 0;
+        z-index: 1
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout.category-item input[type=checkbox]:not(:checked) ~ .accordion-text {
+        margin-top: 0;
+        max-height: 0;
+        opacity: 0;
+        overflow: hidden;
+        width: 100%;
+        transition: .25s ease-out
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout.category-item input[type=checkbox]:checked ~ .accordion-text {
+        transition: .1s ease-in;
+        margin-top: 10px;
+        width: 100%;
+        overflow: auto
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout.category-item input[type=checkbox]:checked ~ .ot-accordion-pc-container {
+        width: auto;
+        margin-top: 0px;
+        padding-bottom: 10px
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout .ot-accordion-group-pc-container {
+        padding-left: 20px;
+        padding-right: 15px;
+        width: calc(100% - 35px);
+        font-size: .82em;
+        margin-bottom: 10px
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout .accordion-header {
+        padding-top: 11.5px;
+        padding-bottom: 11.5px;
+        padding-left: 20px;
+        padding-right: 15px;
+        width: calc(100% - 35px);
+        display: inline-block
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout .accordion-text {
+        width: 100%;
+        padding: 0px
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout .cookie-subgroups-container {
+        padding-left: 20px;
+        padding-right: 15px;
+        padding-bottom: 7.5px;
+        margin: 0;
+        width: calc(100% - 35px)
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout .ot-accordion-pc-container, #onetrust-pc-sdk .ot-accordion-layout .ot-switch.ot-toggle {
+        z-index: 1;
+        position: relative
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout .category-header + .ot-arrow-container {
+        float: right;
+        position: relative
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout .category-header + .ot-arrow-container .ot-arrow {
+        width: 15px;
+        height: 20px;
+        margin-left: 5px;
+        color: dimgray
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout .ot-always-active-group > .ot-arrow-container {
+        top: -2px
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout .category-header {
+        float: none;
+        font-size: .9em;
+        color: #2e3644;
+        margin: 0;
+        display: inline-block;
+        height: auto;
+        word-wrap: break-word
+    }
+
+    #onetrust-pc-sdk .ot-accordion-layout .category-vendors-list-container, #onetrust-pc-sdk .ot-accordion-layout .category-host-list-container {
+        width: calc(100% - 20px);
+        display: inline-block;
+        margin-top: 0px;
+        padding: 10px 0px 10px 20px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .ot-toggle-group {
+        width: 45px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out #manage-cookies-text {
+        padding-bottom: 10px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .leg-int-header {
+        color: #77808e;
+        overflow: hidden;
+        padding-top: 7.5px;
+        padding-bottom: 7.5px;
+        width: calc(100% - 2px);
+        border-top-left-radius: 3px;
+        border-top-right-radius: 3px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .leg-int-header span:first-child {
+        max-width: 80px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .leg-int-header span:last-child {
+        padding-right: 10px;
+        max-width: 95px;
+        text-align: center
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .leg-int-title {
+        float: right;
+        font-size: .813em
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .leg-int-header.ot-leg-border-color {
+        background-color: #f8f8f8;
+        border: 1px solid #e9e9e9
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .leg-int-header.ot-leg-border-color span:first-child {
+        text-align: left;
+        width: 80px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out li.cookie-subgroup > h5, #onetrust-pc-sdk.ot-leg-opt-out .category-header {
+        width: calc(100% - 125px)
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out li.cookie-subgroup > h5 + .cookie-subgroup-toggle {
+        padding-left: 13px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .ot-accordion-pc-container .ot-accordion-group-pc-container {
+        margin-bottom: 5px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .ot-accordion-pc-container .cookie-subgroups-container {
+        border-top: 1px solid #e9e9e9
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .ot-accordion-pc-container ul.cookie-subgroups li {
+        margin-top: 5px;
+        margin-bottom: 5px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .ot-accordion-pc-container li.cookie-subgroup > h5 + .cookie-subgroup-toggle {
+        padding-right: 20px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .accordion-header .ot-arrow-container + .ot-switch.ot-toggle, #onetrust-pc-sdk.ot-leg-opt-out .accordion-text h4 + .ot-switch.ot-toggle {
+        padding-left: 13px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out #select-all-text-container {
+        text-align: right
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .hosts-list #select-all-container .ot-checkbox {
+        margin-right: 80px;
+        right: 0
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .hosts-list #select-all-text-container {
+        width: 94%
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out #select-all-container .ot-checkbox {
+        margin: 0;
+        max-width: 100%;
+        padding: 0;
+        position: relative;
+        right: 77px;
+        width: calc(100% - 77px)
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out #select-all-vendors-input-container {
+        right: 10px;
+        position: relative
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .leg-int-sel-all-hdr {
+        display: block;
+        width: 100%;
+        position: relative;
+        height: 20px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .consent-hdr, #onetrust-pc-sdk.ot-leg-opt-out .leg-int-hdr {
+        float: right;
+        font-size: .8em
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .leg-int-hdr {
+        padding-right: 10px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out #select-all-vendors-leg-input-container {
+        display: block;
+        width: 21px;
+        height: auto;
+        float: right;
+        position: relative;
+        right: 80px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out #select-all-vendors-leg-input-container label {
+        position: absolute
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .ot-vendor-consent-tgl {
+        margin-left: 60px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out .ot-leg-int-tgl + .ot-arrow-container {
+        margin-left: 81px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out #vendor-list-content .ot-toggle-group {
+        width: auto;
+        top: auto
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out #vendor-list-content .ot-checkbox {
+        position: relative;
+        display: inline-block;
+        width: 20px;
+        height: 25px
+    }
+
+    #onetrust-pc-sdk.ot-leg-opt-out #vendor-list-content .ot-checkbox label {
+        position: absolute;
+        padding: 0;
+        width: 18px;
+        height: 18px
+    }
+
+    #onetrust-pc-sdk .ot-always-active-group .category-header {
+        width: 55%
+    }
+
+    #onetrust-pc-sdk .ot-accordion-group-pc-container + .ot-leg-btn-container {
+        padding-left: 20px;
+        padding-right: 15px;
+        width: calc(100% - 35px);
+        margin-bottom: 10px
+    }
+
+    #onetrust-pc-sdk #vendors-list-container .ot-leg-btn-container {
+        margin-top: 10px
+    }
+
+    #onetrust-pc-sdk .ot-leg-btn-container {
+        display: inline-block;
+        width: 100%;
+        margin-bottom: 10px
+    }
+
+    #onetrust-pc-sdk .ot-leg-btn-container button {
+        height: auto;
+        padding: 6.5px 8px;
+        margin-bottom: 0;
+        letter-spacing: 0;
+        line-height: normal
+    }
+
+    #onetrust-pc-sdk .ot-leg-btn-container svg {
+        display: none;
+        height: 14px;
+        width: 14px;
+        padding-right: 5px;
+        vertical-align: sub
+    }
+
+    #onetrust-pc-sdk .ot-active-leg-btn {
+        cursor: default;
+        pointer-events: none
+    }
+
+    #onetrust-pc-sdk .ot-active-leg-btn svg {
+        display: inline-block
+    }
+
+    #onetrust-pc-sdk .ot-remove-objection-handler {
+        border: none;
+        text-decoration: underline;
+        padding: 0;
+        font-size: .82em;
+        font-weight: 600;
+        line-height: 1.4;
+        padding-left: 10px
+    }
+
+    #onetrust-pc-sdk .ot-obj-leg-btn-handler span {
+        font-weight: bold;
+        text-align: center;
+        font-size: .91em;
+        line-height: 1.5
+    }
+
+    #onetrust-pc-sdk.otPcCenter[dir=rtl] .accordion-text .vendor-option p {
+        width: 27%
+    }
+
+    #onetrust-pc-sdk.otPcCenter[dir=rtl] .category-header, #onetrust-pc-sdk.otPcCenter[dir=rtl] .category-vendors-list-container, #onetrust-pc-sdk.otPcCenter[dir=rtl] .ot-toggle-group .ot-checkbox, #onetrust-pc-sdk.otPcCenter[dir=rtl] .ot-group-option, #onetrust-pc-sdk.otPcCenter[dir=rtl] .ot-checkbox label {
+        float: left
+    }
+
+    #onetrust-pc-sdk.otPcCenter[dir=rtl] input ~ .accordion-header .ot-arrow {
+        transform: rotate(180deg);
+        -o-transform: rotate(180deg);
+        -ms-transform: rotate(180deg);
+        -webkit-transform: rotate(180deg)
+    }
+
+    #onetrust-pc-sdk.otPcCenter[dir=rtl] input:checked ~ .accordion-header .ot-arrow {
+        transform: rotate(270deg);
+        -o-transform: rotate(270deg);
+        -ms-transform: rotate(270deg);
+        -webkit-transform: rotate(270deg)
+    }
+
+    #onetrust-pc-sdk.otPcCenter[dir=rtl] #search-container svg {
+        right: 52px
+    }
+
+    #onetrust-pc-sdk.otPcCenter[dir=rtl] #ot-back-arrow {
+        transform: rotate(180deg);
+        -o-transform: rotate(180deg);
+        -ms-transform: rotate(180deg);
+        -webkit-transform: rotate(180deg)
+    }
+
+    #onetrust-pc-sdk.otPcCenter[dir=rtl] .ot-checkbox label::after {
+        transform: rotate(45deg);
+        -webkit-transform: rotate(45deg);
+        -o-transform: rotate(45deg);
+        -ms-transform: rotate(45deg);
+        border-left: 0;
+        border-right: 3px solid
+    }
+
+    @media only screen and (min-width: 389px)and (max-width: 600px) {
+        #onetrust-pc-sdk #select-all-container .ot-checkbox {
+            margin-right: 18.5%
+        }
+
+        #onetrust-pc-sdk #ot-options {
+            max-width: 335px
+        }
+    }
+
+    @media only screen and (max-width: 600px) {
+        #onetrust-pc-sdk.ot-leg-opt-out #select-all-container .ot-checkbox {
+            right: 28px;
+            width: calc(100% - 28px)
+        }
+
+        #onetrust-pc-sdk .vendor-purposes {
+            transform: translate(50%, 150%);
+            -o-transform: translate(50%, 150%);
+            -ms-transform: translate(50%, 150%);
+            -webkit-transform: translate(50%, 150%)
+        }
+
+        #onetrust-pc-sdk #ot-content {
+            margin: 0 3px 0 20px;
+            padding-right: 10px;
+            width: calc(100% - 33px)
+        }
+
+        #onetrust-pc-sdk #close-pc-btn-handler, #onetrust-pc-sdk #vendor-close-pc-btn-handler {
+            top: 10px;
+            right: 17px
+        }
+
+        #onetrust-pc-sdk #vendor-list-content .ot-sdk-column {
+            padding-right: 0
+        }
+
+        #onetrust-pc-sdk #vendor-list-save-btn {
+            width: 87%;
+            left: 20px;
+            padding-left: 0px;
+            top: 20px
+        }
+
+        #onetrust-pc-sdk #pc-title {
+            font-size: 1.2em
+        }
+
+        #onetrust-pc-sdk p {
+            font-size: .7em
+        }
+
+        #onetrust-pc-sdk .ot-arrow {
+            margin-left: 10px
+        }
+
+        #onetrust-pc-sdk #vendors-list-header {
+            margin: 10px 10px 0 5px;
+            width: 100%
+        }
+
+        #onetrust-pc-sdk #vendor-search-handler {
+            margin-left: 15px;
+            width: 75%;
+            max-width: 325px
+        }
+
+        #onetrust-pc-sdk #no-results p, #onetrust-pc-sdk #vendors-list-title {
+            width: 90vw
+        }
+
+        #onetrust-pc-sdk input {
+            font-size: 1em !important
+        }
+
+        #onetrust-pc-sdk #ot-back-arrow {
+            margin-left: 12px
+        }
+
+        #onetrust-pc-sdk #vendor-list-content {
+            margin: 0;
+            padding: 0 5px 0 10px;
+            min-width: 95%
+        }
+
+        #onetrust-pc-sdk #select-all-container {
+            max-width: 90%;
+            min-width: 95%
+        }
+
+        #onetrust-pc-sdk #select-all-container .ot-checkbox {
+            margin-right: 21px
+        }
+
+        #onetrust-pc-sdk .switch + p {
+            max-width: 80%
+        }
+
+        #onetrust-pc-sdk button {
+            width: 100%
+        }
+
+        #onetrust-pc-sdk .button-theme {
+            letter-spacing: .01em
+        }
+
+        #onetrust-pc-sdk #ot-options {
+            left: 20px;
+            max-width: 320px;
+            width: 100%;
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0
+        }
+
+        #onetrust-pc-sdk button.ot-pill {
+            padding: 9px;
+            max-width: 100px
+        }
+
+        #onetrust-pc-sdk .ot-group-option {
+            margin-left: 25px;
+            margin-bottom: 10px
+        }
+
+        #onetrust-pc-sdk .ot-pc-footer-logo {
+            width: 100%;
+            text-align: center;
+            margin-top: 0px
+        }
+
+        #onetrust-pc-sdk .ot-pc-footer-logo a {
+            width: auto
+        }
+
+        #onetrust-pc-sdk .hosts-list .back-btn-handler {
+            padding-left: 0px
+        }
+
+        #onetrust-pc-sdk .hosts-list #vendors-list-title {
+            margin-left: 20px
+        }
+
+        #onetrust-pc-sdk .host-list-content {
+            margin-left: 0px
+        }
+
+        #onetrust-pc-sdk .host-list-content + #vendor-list-save-btn {
+            padding-left: 0px;
+            margin-top: 25px
+        }
+
+        #onetrust-pc-sdk .hosts-list #vendor-search-handler {
+            margin-left: 15px
+        }
+
+        #onetrust-pc-sdk .ot-pc-refuse-all-handler.button-theme {
+            margin-bottom: 0
+        }
+
+        #onetrust-pc-sdk.otPcCenter {
+            left: 0;
+            min-width: 100%;
+            height: 100%;
+            top: 0;
+            border-radius: 0
+        }
+
+        #onetrust-pc-sdk.otPcCenter[dir=rtl]:not(.ot-leg-btn) #select-all-container .ot-checkbox {
+            margin-right: 46px
+        }
+
+        #onetrust-pc-sdk.otPcCenter[dir=rtl] input ~ .accordion-header .ot-arrow {
+            transform: rotate(180deg);
+            -o-transform: rotate(180deg);
+            -ms-transform: rotate(180deg);
+            -webkit-transform: rotate(180deg)
+        }
+
+        #onetrust-pc-sdk.otPcCenter[dir=rtl] input:checked ~ .accordion-header .ot-arrow {
+            transform: rotate(270deg);
+            -o-transform: rotate(270deg);
+            -ms-transform: rotate(270deg);
+            -webkit-transform: rotate(270deg)
+        }
+    }
+
+    @media only screen and (max-width: 320px) {
+        #onetrust-pc-sdk #select-all-container .ot-checkbox {
+            margin-right: 28px
+        }
+
+        #onetrust-pc-sdk #filter-icon {
+            margin-top: 9px
+        }
+
+        #onetrust-pc-sdk #vendor-search-handler {
+            width: 72%
+        }
+
+        #onetrust-pc-sdk #search-container svg {
+            right: 40px
+        }
+
+        #onetrust-pc-sdk .vendor-purposes {
+            transform: translate(20%, 150%);
+            -o-transform: translate(20%, 150%);
+            -ms-transform: translate(20%, 150%);
+            -webkit-transform: translate(20%, 150%)
+        }
+
+        #onetrust-pc-sdk .vendor-option a {
+            width: 150px
+        }
+
+        #onetrust-pc-sdk .vendor-option a svg {
+            width: 14px
+        }
+
+        #onetrust-pc-sdk .back-btn-handler p {
+            margin-bottom: 0
+        }
+
+        #onetrust-pc-sdk #ot-options {
+            width: 88%
+        }
+    }
+
+    @media only screen and (min-width: 600px)and (max-width: 896px)and (max-height: 425px)and (orientation: landscape) {
+        #onetrust-pc-sdk #ot-triangle {
+            left: initial;
+            right: 40vw
+        }
+
+        #onetrust-pc-sdk .button-theme {
+            letter-spacing: .02em
+        }
+
+        #onetrust-pc-sdk #select-all-container .ot-checkbox, #onetrust-pc-sdk.otPcCenter[dir=rtl] #select-all-container .ot-checkbox {
+            margin-right: 10px
+        }
+
+        #onetrust-pc-sdk #vendors-list-title {
+            margin-top: 12px
+        }
+
+        #onetrust-pc-sdk #vendors-list-title * {
+            font-size: inherit
+        }
+
+        #onetrust-pc-sdk #vendor-list-save-btn {
+            position: absolute;
+            top: 160px;
+            right: 0px
+        }
+
+        #onetrust-pc-sdk #vendor-list-save-btn button {
+            max-width: 150px;
+            padding: 6px 30px
+        }
+
+        #onetrust-pc-sdk #vendors-list-header input {
+            margin-right: 0;
+            padding-right: 45px
+        }
+
+        #onetrust-pc-sdk #vendor-search-handler {
+            width: 415px
+        }
+
+        #onetrust-pc-sdk .switch + p {
+            max-width: 85%
+        }
+
+        #onetrust-pc-sdk #select-all-container {
+            max-width: none
+        }
+
+        #onetrust-pc-sdk #vendor-list-content {
+            min-width: 68%;
+            width: 68%;
+            bottom: 0;
+            height: calc(100% - 190px)
+        }
+
+        #onetrust-pc-sdk #vendor-list-content.no-results {
+            height: auto
+        }
+
+        #onetrust-pc-sdk input {
+            font-size: 1em !important
+        }
+
+        #onetrust-pc-sdk p {
+            font-size: .6em
+        }
+
+        #onetrust-pc-sdk .vendor-option p {
+            font-size: .6em
+        }
+
+        #onetrust-pc-sdk .vendor-option a {
+            width: 70px
+        }
+
+        #onetrust-pc-sdk #ot-filter-modal {
+            width: 100%;
+            top: 0
+        }
+
+        #onetrust-pc-sdk #ot-options {
+            height: 250px;
+            width: 100%
+        }
+
+        #onetrust-pc-sdk ul li p, #onetrust-pc-sdk .category-vendors-list-handler, #onetrust-pc-sdk .category-vendors-list-handler + a, #onetrust-pc-sdk .category-host-list-handler {
+            font-size: .6em
+        }
+
+        #onetrust-pc-sdk.otPcCenter {
+            left: 0;
+            top: 0;
+            min-width: 100%;
+            height: 100%;
+            border-radius: 0
+        }
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk,
+    #onetrust-consent-sdk #search-container,
+    #onetrust-consent-sdk #onetrust-pc-sdk .ot-switch.ot-toggle,
+    #onetrust-consent-sdk #onetrust-pc-sdk group-toggle .checkbox,
+    #onetrust-consent-sdk #onetrust-pc-sdk #pc-title:after {
+        background-color: #000;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk h3,
+    #onetrust-consent-sdk #onetrust-pc-sdk h4,
+    #onetrust-consent-sdk #onetrust-pc-sdk h5,
+    #onetrust-consent-sdk #onetrust-pc-sdk h6,
+    #onetrust-consent-sdk #onetrust-pc-sdk p,
+    #onetrust-consent-sdk #onetrust-pc-sdk #vendors-list-container .vendor-options p,
+    #onetrust-consent-sdk #onetrust-pc-sdk #pc-policy-text,
+    #onetrust-consent-sdk #onetrust-pc-sdk #pc-title,
+    #onetrust-consent-sdk #onetrust-pc-sdk .leg-int-title,
+    #onetrust-consent-sdk #onetrust-pc-sdk .leg-int-sel-all-hdr span,
+    #onetrust-consent-sdk #onetrust-pc-sdk #hosts-list-container .vendor-host,
+    #onetrust-consent-sdk #onetrust-pc-sdk #ot-filter-modal #modal-header,
+    #onetrust-consent-sdk #onetrust-pc-sdk .ot-checkbox label span,
+    #onetrust-consent-sdk #onetrust-pc-sdk #vendors-list #select-all-container p,
+    #onetrust-consent-sdk #onetrust-pc-sdk #vendors-list #vendors-list-title,
+    #onetrust-consent-sdk #onetrust-pc-sdk #vendors-list .back-btn-handler p,
+    #onetrust-consent-sdk #onetrust-pc-sdk #vendors-list .vendor-title,
+    #onetrust-consent-sdk #onetrust-pc-sdk #vendors-list #vendors-list-container .consent-category,
+    #onetrust-consent-sdk #onetrust-pc-sdk .ot-leg-btn-container .ot-inactive-leg-btn,
+    #onetrust-consent-sdk #onetrust-pc-sdk .ot-label-status,
+    #onetrust-consent-sdk #onetrust-pc-sdk .ot-chkbox label span,
+    #onetrust-consent-sdk #onetrust-pc-sdk #clear-filters-handler {
+        color: #696969;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk .privacy-notice-link,
+    #onetrust-consent-sdk #onetrust-pc-sdk .category-vendors-list-handler,
+    #onetrust-consent-sdk #onetrust-pc-sdk .category-vendors-list-handler + a,
+    #onetrust-consent-sdk #onetrust-pc-sdk .category-host-list-handler,
+    #onetrust-consent-sdk #onetrust-pc-sdk .vendor-privacy-notice,
+    #onetrust-consent-sdk #onetrust-pc-sdk #hosts-list-container .host-title a,
+    #onetrust-consent-sdk #onetrust-pc-sdk #hosts-list-container .accordion-header .host-view-cookies,
+    #onetrust-consent-sdk #onetrust-pc-sdk #hosts-list-container .vendor-host a {
+        color: #3860BE;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk .category-vendors-list-handler:hover {
+        opacity: .7;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk .ot-accordion-pc-container.accordion-text,
+    #onetrust-consent-sdk #onetrust-pc-sdk .accordion-text .cookie-subgroup-toggle .ot-switch.ot-toggle {
+        background-color: #F8F8F8;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk #hosts-list-container .vendor-host,
+    #onetrust-consent-sdk #onetrust-pc-sdk .accordion-text .vendor-options {
+        background-color: #F8F8F8;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk
+    button:not(#clear-filters-handler):not(.ot-close-icon):not(#filter-btn-handler):not(.ot-remove-objection-handler):not(.ot-obj-leg-btn-handler):not([aria-expanded]):not(.ot-link-btn),
+    #onetrust-consent-sdk #onetrust-pc-sdk .ot-leg-btn-container .ot-active-leg-btn {
+        background-color: #6CC04A;
+        border-color: #6CC04A;
+        color: #FFFFFF;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk .active-group {
+        border-color: #6CC04A;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk .ot-leg-btn-container .ot-remove-objection-handler {
+        background-color: transparent;
+        border: 1px solid transparent;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk .ot-leg-btn-container .ot-inactive-leg-btn {
+        background-color: #FFFFFF;
+        color: #78808E;
+        border-color: #78808E;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk .ot-tgl input:focus + .ot-switch, .ot-switch .ot-switch-nob, .ot-switch .ot-switch-nob:before,
+    #onetrust-pc-sdk .ot-checkbox input[type="checkbox"]:focus + label::before,
+    #onetrust-pc-sdk .ot-chkbox input[type="checkbox"]:focus + label::before {
+        outline-color: #000000;
+        outline-width: 1px;
+    }
+
+    #onetrust-pc-sdk .ot-host-item > button:focus, #onetrust-pc-sdk .ot-ven-item > button:focus {
+        border: 1px solid #000000;
+    }
+
+    #onetrust-consent-sdk #onetrust-pc-sdk *:focus,
+    #onetrust-consent-sdk #onetrust-pc-sdk .ot-vlst-cntr > a:focus {
+        outline: 1px solid #000000;
+    }
+
+    #onetrust-pc-sdk input[type="checkbox"]:focus + .accordion-header,
+    #onetrust-pc-sdk .category-item .ot-switch.ot-toggle input:focus + .ot-switch-label,
+    #onetrust-pc-sdk .checkbox input:focus + label::after {
+        outline-color: #000000;
+        outline-width: 1px;
+    }
+
+    #onetrust-pc-sdk .ot-pc-footer-logo .powered-by-logo {
+
+        display: none;
+
+    }
+
+    #onetrust-pc-sdk .pc-logo {
+
+        display: none;
+
+    }
+
+    .ot-sdk-cookie-policy {
+        font-family: inherit;
+        font-size: 16px
+    }
+
+    .ot-sdk-cookie-policy.otRelFont {
+        font-size: 1rem
+    }
+
+    .ot-sdk-cookie-policy h3, .ot-sdk-cookie-policy h4, .ot-sdk-cookie-policy h6, .ot-sdk-cookie-policy p, .ot-sdk-cookie-policy li, .ot-sdk-cookie-policy a, .ot-sdk-cookie-policy th, .ot-sdk-cookie-policy #cookie-policy-description, .ot-sdk-cookie-policy .ot-sdk-cookie-policy-group, .ot-sdk-cookie-policy #cookie-policy-title {
+        color: dimgray
+    }
+
+    .ot-sdk-cookie-policy #cookie-policy-description {
+        margin-bottom: 1em
+    }
+
+    .ot-sdk-cookie-policy h4 {
+        font-size: 1.2em
+    }
+
+    .ot-sdk-cookie-policy h6 {
+        font-size: 1em;
+        margin-top: 2em
+    }
+
+    .ot-sdk-cookie-policy th {
+        min-width: 75px
+    }
+
+    .ot-sdk-cookie-policy a, .ot-sdk-cookie-policy a:hover {
+        background: #fff
+    }
+
+    .ot-sdk-cookie-policy thead {
+        background-color: #f6f6f4;
+        font-weight: bold
+    }
+
+    .ot-sdk-cookie-policy .ot-mobile-border {
+        display: none
+    }
+
+    .ot-sdk-cookie-policy section {
+        margin-bottom: 2em
+    }
+
+    .ot-sdk-cookie-policy table {
+        border-collapse: inherit
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy {
+        font-family: inherit;
+        font-size: 1rem
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h3, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h4, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h6, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy p, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy li, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy a, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy th, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-description, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-group, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-title {
+        color: dimgray
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-description {
+        margin-bottom: 1em
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-subgroup {
+        margin-left: 1.5em
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-description, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-group-desc, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-table-header, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy a, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy span, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td {
+        font-size: .9em
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td span, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td a {
+        font-size: inherit
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-group {
+        font-size: 1em;
+        margin-bottom: .6em
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-title {
+        margin-bottom: 1.2em
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy > section {
+        margin-bottom: 1em
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy th {
+        min-width: 75px
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy a, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy a:hover {
+        background: #fff
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy thead {
+        background-color: #f6f6f4;
+        font-weight: bold
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-mobile-border {
+        display: none
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy section {
+        margin-bottom: 2em
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-subgroup ul li {
+        list-style: disc;
+        margin-left: 1.5em
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-subgroup ul li h4 {
+        display: inline-block
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table {
+        border-collapse: inherit;
+        margin: auto;
+        border: 1px solid #d7d7d7;
+        border-radius: 5px;
+        border-spacing: initial;
+        width: 100%;
+        overflow: hidden
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table th, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table td {
+        border-bottom: 1px solid #d7d7d7;
+        border-right: 1px solid #d7d7d7
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table tr:last-child td {
+        border-bottom: 0px
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table tr th:last-child, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table tr td:last-child {
+        border-right: 0px
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table .ot-host, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table .ot-cookies-type {
+        width: 25%
+    }
+
+    .ot-sdk-cookie-policy[dir=rtl] {
+        text-align: left
+    }
+
+    #ot-sdk-cookie-policy h3 {
+        font-size: 1.5em
+    }
+
+    @media only screen and (max-width: 530px) {
+        .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) table, .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) thead, .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) tbody, .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) th, .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) td, .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) tr {
+            display: block
+        }
+
+        .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) thead tr {
+            position: absolute;
+            top: -9999px;
+            left: -9999px
+        }
+
+        .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) tr {
+            margin: 0 0 1em 0
+        }
+
+        .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) tr:nth-child(odd), .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) tr:nth-child(odd) a {
+            background: #f6f6f4
+        }
+
+        .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) td {
+            border: none;
+            border-bottom: 1px solid #eee;
+            position: relative;
+            padding-left: 50%
+        }
+
+        .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) td:before {
+            position: absolute;
+            height: 100%;
+            left: 6px;
+            width: 40%;
+            padding-right: 10px
+        }
+
+        .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) .ot-mobile-border {
+            display: inline-block;
+            background-color: #e4e4e4;
+            position: absolute;
+            height: 100%;
+            top: 0;
+            left: 45%;
+            width: 2px
+        }
+
+        .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) td:before {
+            content: attr(data-label);
+            font-weight: bold
+        }
+
+        .ot-sdk-cookie-policy:not(#ot-sdk-cookie-policy-v2) li {
+            word-break: break-word;
+            word-wrap: break-word
+        }
+
+        #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table {
+            overflow: hidden
+        }
+
+        #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table td {
+            border: none;
+            border-bottom: 1px solid #d7d7d7
+        }
+
+        #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy thead, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy tbody, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy th, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy tr {
+            display: block
+        }
+
+        #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table .ot-host, #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table .ot-cookies-type {
+            width: auto
+        }
+
+        #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy tr {
+            margin: 0 0 1em 0
+        }
+
+        #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td:before {
+            height: 100%;
+            width: 40%;
+            padding-right: 10px
+        }
+
+        #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td:before {
+            content: attr(data-label);
+            font-weight: bold
+        }
+
+        #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy li {
+            word-break: break-word;
+            word-wrap: break-word
+        }
+
+        #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy thead tr {
+            position: absolute;
+            top: -9999px;
+            left: -9999px;
+            z-index: -9999
+        }
+
+        #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table tr:last-child td {
+            border-bottom: 1px solid #d7d7d7;
+            border-right: 0px
+        }
+
+        #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table tr:last-child td:last-child {
+            border-bottom: 0px
+        }
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h5,
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy h6,
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy li,
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy p,
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy a,
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy span,
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy td,
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-description {
+        color: #696969;
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy th {
+        color: #696969;
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy .ot-sdk-cookie-policy-group {
+        color: #696969;
+    }
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy #cookie-policy-title {
+        color: #696969;
+    }
+
+
+    #ot-sdk-cookie-policy-v2.ot-sdk-cookie-policy table th {
+        background-color: #F8F8F8;
+    }
+
+    </style>
+    <link rel="stylesheet" type="text/css"
+          href="https://open.scdn.co/cdn/build/web-player/xpui-routes-search.22ccf680.css">
+    <link rel="stylesheet" type="text/css"
+          href="https://open.scdn.co/cdn/build/web-player/xpui-routes-artist.abe4b471.css">
+</head>
+<body class="" data-locale="en" data-market="DK">
+<div class="body-drag-top"></div>
+<script id="jsonTranslations" type="application/json" data-locale="en">{
+    "error-dialog.generic.header": "Something went wrong",
+    "error-dialog.generic.body": "Try reloading the page",
+    "fatal-error.button-label": "RELOAD PAGE",
+    "offline.feedback-text": "Not available while you're offline.",
+    "error.generic": "Something went wrong.",
+    "queue.added-to-queue": "Added to queue",
+    "feedback.added-to-playlist-generic": "Added to Playlist",
+    "feedback.saved-to-your-library": "Saved to Your Library",
+    "feedback.removed-from-your-library": "Removed from Your Library",
+    "feedback.added-to-your-liked-songs": "Added to your Liked Songs",
+    "feedback.added-to-your-episodes": "Added to Your Episodes",
+    "feedback.removed-from-your-liked-songs": "Removed from your Liked Songs",
+    "feedback.removed-from-your-episodes": "Removed from Your Episodes",
+    "feedback.link-copied": "Link copied to clipboard",
+    "error.playback": "Something went wrong with the playback.",
+    "feedback.unable-to-play": "This content is not available.",
+    "pwa.confirm": "Welcome to your Spotify app",
+    "feedback.radio.ban-track": "Got it. We won't play that song in this station.",
+    "feedback.format-list-ban-artist": "Got it. From now on we won’t put {0} in {1}.",
+    "feedback.format-list-ban-track": "Got it. Next time, we won't recommend songs like that in {1}.",
+    "feedback.playlist-publish": "Playlist is now displayed on your profile.",
+    "feedback.playlist-unpublish": "Playlist is no longer displayed on your profile.",
+    "feedback.block-user": "You have blocked this account.",
+    "feedback.unblock-user": "You have unblocked this account.",
+    "feedback.employee-podcast-access": "You now have access to employee only content.",
+    "error.not_found.body": "Search for something else?",
+    "ad-formats.advertisement": "Advertisement",
+    "search.a11y.clear-input": "Clear search field",
+    "action-trigger.enjoy-library": "Enjoy Your Library",
+    "action-trigger.login-library": "Log in to see saved songs, podcasts, artists, and playlists in Your Library.",
+    "action-trigger.save-library": "Save for later",
+    "action-trigger.logged-out-continue": "Log in to continue.",
+    "action-trigger.logged-out": "You’re logged out",
+    "action-trigger.logged-out-queue": "Log in to add to queue.",
+    "action-trigger.logged-out-radio": "Log in to start radio.",
+    "action-trigger.log-in-like-action": "Log in to add this to your Liked Songs.",
+    "action-trigger.log-in-follow-profile": "Log in to follow this profile on Spotify.",
+    "action-trigger.logged-out-full-track": "Open the app or log in to listen to the full track.",
+    "action-trigger.logged-out-synced": "Log in to sync listening history across all of your devices.",
+    "action-trigger.liked-songs": "Enjoy your Liked Songs",
+    "action-trigger.login-liked-songs": "Log in to see all the songs you’ve liked in one easy playlist.",
+    "action-trigger.create-playlist": "Create a playlist",
+    "action-trigger.login-playlist": "Log in to create and share playlists.",
+    "page.loading": "Loading",
+    "search.empty-results-title": "No results found for \"{0}\"",
+    "search.empty-results-text": "Please make sure your words are spelled correctly or use less or different keywords.",
+    "browser_upgrade_notice": "Spotify no longer supports this version of {0}. Please update your browser for uninterrupted listening.",
+    "sidebar.a11y.landmark-label": "Main",
+    "feedback.cant-play-track": "Can't play the current song.",
+    "feedback.track-not-available-forced-offline": "Please turn off offline mode and try again.",
+    "feedback.cant-offline-sync-playlist-in-offline-mode": "Please turn off offline mode to download.",
+    "feedback.artist-banned-by-user": "We can't play this until you allow this artist in the Spotify phone app.",
+    "feedback.track-banned-by-user": "We can't play this until you allow this track in the Spotify phone app.",
+    "feedback.track-not-available-in-region": "Spotify can't play this in {0}. If you have the file on your computer you can import it.",
+    "feedback.track-not-available": "Spotify can't play this right now. If you have the file on your computer you can import it.",
+    "feedback.track-exclusive-premium": "Spotify can't play this right now.",
+    "feedback.cant-skip-ads": "The selected song will be played after the ads.",
+    "feedback.cant-play-during-ads": "Please try that again after this ad.",
+    "feedback.skip-ads-to-hear-song": "Your track will play after the ads. Skip ads to get back to your music faster!",
+    "feedback.skip-ads-after-delay": "You'll be able to skip the ad and get back to your content after {0} seconds.",
+    "capping.upsell-title": "You've reached your free listening limit.",
+    "feedback.video-georestricted": "We're not able to play this video in your current location.",
+    "feedback.video-unsupported-client-version": "Please upgrade Spotify to play this video.",
+    "feedback.video-unsupported-platform-version": "This video cannot be played on your operating system version.",
+    "feedback.video-country-restricted": "We're not able to play this video in your current location.",
+    "feedback.video-unavailable": "This video is unavailable. Try another?",
+    "feedback.video-catalogue-restricted": "Sorry, we're not able to play this video.",
+    "feedback.video-playback-error": "Sorry, we're not able to play this video.",
+    "feedback.video-unsupported-key-system": "Hmm... we can't seem to play this video. Try installing the latest version of Spotify.",
+    "feedback.explicit-content-filtered": "Spotify can't play this right now because it contains explicit content.",
+    "feedback.play-after-ad": "The selected content will play after the ads",
+    "downloadPage.page-title": "Spotify – Download for Desktop",
+    "error.not_found.title.page": "Couldn't find that page",
+    "search.page-title": "Spotify – Search",
+    "error.not_found.title.playlist": "Couldn't find that playlist",
+    "playlist.page-title": "Spotify – {0}",
+    "sidebar.collaborative_playlist": "Collaborative Playlist",
+    "playlist": "Playlist",
+    "playlist.edit-details.button": "{0} – Edit details",
+    "playlist.a11y.play": "Play {0}",
+    "playlist.a11y.pause": "Pause {0}",
+    "more.label.context": "More options for {0}",
+    "playlist.search_in_playlist": "Search in playlist",
+    "playlist.empty_state_subtitle": "Let's find some songs for your playlist",
+    "playlist.empty_state_title": "It's a bit empty here...",
+    "browse.new-releases": "NEW RELEASES",
+    "playlist.curation.find_more": "Find more",
+    "page.generic-title": "Spotify – Web Player",
+    "desktop.settings.settings": "Settings",
+    "desktop.settings.hideAdvancedSettings": "Hide advanced settings",
+    "desktop.settings.showAdvancedSettings": "Show advanced settings",
+    "view.recently-played": "Recently played",
+    "playlist-radio.header.oneFeaturedArtist": "Featuring {0}.",
+    "playlist-radio.header.twoFeaturedArtists": "Featuring {0} and {1}.",
+    "playlist-radio.header.threeFeaturedArtists": "Featuring {0}, {1}, and {2}.",
+    "playlist-radio.header.moreThanThreeFeaturedArtists": "Featuring {0}, {1}, {2} and more.",
+    "playlist-radio": "Playlist Radio",
+    "song-radio": "Song Radio",
+    "album-radio": "Album Radio",
+    "artist-radio": "Artist Radio",
+    "radio": "Radio",
+    "error.not_found.title.station": "Couldn't find that station",
+    "music_downloads": "Music Downloads",
+    "type.showEpisode": "Show Episode",
+    "type.podcastEpisode": "Podcast Episode",
+    "error.not_found.title.podcast": "Couldn't find that podcast",
+    "tracklist.a11y.play": "Play {0} by {1}",
+    "tracklist.a11y.pause": "Pause {0} by {1}",
+    "podcasts.episode.seo.title": "%name% - %show% | Podcast on Spotify",
+    "episode.description-title": "Episode Description",
+    "episode.see_all_episodes": "See all episodes",
+    "type.show": "SHOW",
+    "type.podcast": "Podcast",
+    "podcasts.show.seo.title": "%name% | Podcast on Spotify",
+    "artist.about": "About",
+    "mwp.podcast.all.episodes": "All Episodes",
+    "folder.title": "Playlist Folder",
+    "folder.empty.title": "Start adding playlists",
+    "folder.empty.subtitle": "Just drag and drop within the Playlists panel",
+    "concerts_upcoming_virtual_events": "Upcoming virtual events",
+    "concerts_recommended_for_you": "Recommended for you",
+    "concerts_popular_near_you": "Popular near you",
+    "playlists": "Playlists",
+    "concerts.default_location": "Your Location",
+    "error.request-browse-concerts-failure": "Something went wrong while loading the concerts.",
+    "concerts.error.no_concerts_found_title": "We couldn't find concerts in your location.",
+    "concerts.error.no_concerts_found_message": "We couldn't find concerts in {0}.",
+    "concerts.label": "Concerts",
+    "error.request-collection-tracks-failure": "Something went wrong while loading your songs.",
+    "collection.empty-page.songs-subtitle": "Save songs by tapping the heart icon.",
+    "collection.empty-page.songs-title": "Songs you like will appear here",
+    "collection.empty-page.songs-cta": "Find songs",
+    "error.request-artist-failure": "Something went wrong while loading the artist.",
+    "local-files.empty-button": "Go to Settings",
+    "local-files.empty-description": "Add a source or turn off local files in Settings.",
+    "local-files.empty-header": "Listen to local files",
+    "local-files": "Local Files",
+    "local-files.description": "Files from your computer",
+    "collection.page-title": "Spotify – Your Library",
+    "concert.error.concert_not_found_title": "We couldn't find the concert you're looking for.",
+    "collection.empty-page.episodes-subtitle": "Save episodes to this playlist by tapping the plus icon.",
+    "collection.empty-page.episodes-title": "Add to Your Episodes",
+    "collection.empty-page.shows-cta": "Find podcasts",
+    "song": "Song",
+    "track-page.error": "Couldn't find that song",
+    "single": "Single",
+    "ep": "EP",
+    "compilation": "Compilation",
+    "album": "Album",
+    "album.page-title": "Spotify – {0}",
+    "windowed.product-album-header": "Premium Only",
+    "windowed.product-album-description": "This artist has asked us to release this album on Premium only for a little while, but check back soon.",
+    "album-page.more-releases": {
+        "one": "{0} more release",
+        "other": "{0} more releases"
+    },
+    "album-page.more-by-artist": "More by {0}",
+    "artist-page.show-discography": "See discography",
+    "error.not_found.title.album": "Couldn't find that album",
+    "login": "Log in",
+    "action-trigger.button.not-now": "Not now",
+    "close": "Close",
+    "error-page.header.max_subscriptions_reached": "So you've discovered the tab limit...",
+    "error-page.subtext.max_subscriptions_reached": "You've got too many tabs open. Close this one and continue listening.",
+    "error-page.header.cdmerror": "Enable secure playback in your browser",
+    "error-page.subtext.cdmerror": "Visit the Spotify support site to see how.",
+    "error-page.cta.cdmerror": "GO TO SUPPORT SITE",
+    "fatal-error.header": "An error occurred",
+    "offline-error.device-limit-reached.header": "Download error",
+    "offline-error.device-limit-reached.message": "You’ve reached the limit of offline devices. Remove downloads from a device not in use to download on this one again.",
+    "error.reload": "Reload",
+    "view.web-player-home": "Home",
+    "navbar.search": "Search",
+    "navbar.your-library": "Your Library",
+    "playlist.delete": "Delete {0}?",
+    "playlist.delete-description": "This action cannot be undone.",
+    "playlist.delete-cancel": "CANCEL",
+    "playlist.delete-confirm": "DELETE",
+    "folder.delete-header": "Do you really want to delete this folder and all playlists inside?",
+    "age.restriction.confirmAge": "Confirm your age",
+    "employee-podcasts.modal.title": "These podcasts are meant for Spotify employee ears only.",
+    "employee-podcasts.modal.access.button": "Get Access",
+    "resize.sidebar": "Resize main navigation",
+    "mwp.d2p.modal.title": "Music without limits",
+    "mwp.d2p.modal.description": "Premium lets you enjoy all the music on Spotify, ad-free. Play any song, anytime. Even offline.",
+    "mwp.d2p.modal.cta": "Get Premium",
+    "mwp.d2p.modal.dismiss": "Dismiss",
+    "midyear.cta": "Get 3 months free",
+    "midyear.title": "Try 3 months of Spotify Premium, free.",
+    "midyear.intro": "Enjoy ad-free music listening, offline listening, and more. Cancel anytime.",
+    "midyear.terms": "Monthly subscription fee applies after. Limited eligibility, <a target=\"_blank\" href=\"%help_link%\">terms apply</a>.",
+    "premium.dialog.title": "Get Spotify Premium",
+    "premium.dialog.description": {
+        "one": "Enjoy unlimited access to music, personalized playlists, and more. Eligible members receive their first month on us.",
+        "other": "Enjoy unlimited access to music, personalized playlists, and more. Eligible members receive their first {0} months on us."
+    },
+    "premium.dialog.subscribe": "Subscribe",
+    "user.log-out": "Log out",
+    "premium.dialog.disclaimer.noprice": "Terms and conditions apply.",
+    "premium.dialog.disclaimer": "%price%/month after. Terms and conditions apply. One month free not available for users who have already tried Premium.",
+    "s2l.download_spotify": "Download Spotify",
+    "s2l.play_millions_podcasts": "Play millions of songs and podcasts on your device.",
+    "s2l.play_millions": "Play millions of songs on your device.",
+    "s2l.download": "Download",
+    "s2l.dismiss": "Dismiss",
+    "duplicate.tracks.oneAlreadyAdded": "This is already in your '{0}' playlist.",
+    "duplicate.tracks.allAlreadyAdded": "These are already in your '{0}' playlist.",
+    "duplicate.tracks.someAlreadyAddedDescription": "Some of these are already in your '{0}' playlist.",
+    "duplicate.tracks.alreadyAdded": "Already added",
+    "duplicate.tracks.someAlreadyAdded": "Some already added",
+    "duplicate.tracks.addAll": "Add all",
+    "duplicate.tracks.addAnyway": "Add anyway",
+    "duplicate.tracks.addNewOnes": "Add new ones",
+    "duplicate.tracks.dontAdd": "Don't add",
+    "context-menu.about-recommendations": "About recommendations",
+    "close_button_action": "Close",
+    "block-user.dialog.title": "Block {0}?",
+    "block-user.dialog.description": "{0} will no longer be able to see your profile, follow you, or see your listening activity.",
+    "block-user.dialog.cancel": "Cancel",
+    "block-user.dialog.block": "Block",
+    "track-credits.label": "Credits",
+    "track-credits.source": "Source",
+    "track-credits.additional-credits": "Additional credits",
+    "keyboard.shortcuts.help.heading": "Keyboard Shortcuts",
+    "keyboard.shortcuts.help.subheading.press": "Press",
+    "keyboard.shortcuts.help.subheading.toToggle": "to toggle this modal.",
+    "keyboard.shortcuts.section.basic": "Basic",
+    "keyboard.shortcuts.section.playback": "Playback",
+    "keyboard.shortcuts.section.navigation": "Navigation",
+    "keyboard.shortcuts.section.layout": "Layout",
+    "download-page.header": "Get our free app",
+    "download-page.subtext": "Seamlessly listen to music you love. Download the Spotify app for your computer.",
+    "download-page.button": "DOWNLOAD DESKTOP APP",
+    "ad-formats.dismissAd": "Hide Advertisement",
+    "ewg.title.show": "Embed show",
+    "ewg.title.episode": "Embed episode",
+    "ewg.title.track": "Embed track",
+    "ewg.title.album": "Embed album",
+    "ewg.title.artist": "Embed artist",
+    "ewg.title.playlist": "Embed playlist",
+    "ewg.title": "Embed",
+    "ewg.copy": "Copy",
+    "ewg.copied": "Copied!",
+    "ewg.color": "Color",
+    "ewg.size": "Size",
+    "ewg.size.normal": "Normal",
+    "ewg.size.compact": "Compact",
+    "ewg.help": "Help",
+    "ewg.help-text": "When set to 100%, the player width will automatically expand to fit mobile and desktop layouts.",
+    "ewg.terms": "By embedding a Spotify player on your site, you are agreeing to Spotify's API <a href=\"%s\" target=\"_blank\">Terms of Service</a>",
+    "ewg.start-at": "Start at",
+    "ewg.showcode": "Show code",
+    "search.title.recent-searches": "Recent searches",
+    "search.clear-recent-searches": "Clear recent searches",
+    "search.search-for-label": "Artists, songs, or podcasts",
+    "search.showing-category-query-artist": "All artists for “{0}”",
+    "search.showing-category-query-albums": "All albums for “{0}”",
+    "search.showing-category-query-playlists": "All playlists for “{0}”",
+    "search.showing-category-query-podcasts": "All podcasts for “{0}”",
+    "search.showing-category-query-episodes": "All episodes for “{0}”",
+    "search.showing-category-query-profiles": "All profiles for “{0}”",
+    "search.showing-category-query-genres": "All genres for “{0}”",
+    "remove_from_your_library": "Remove from Your Library",
+    "save_to_your_library": "Save to Your Library",
+    "play": "Play",
+    "mwp.header.content.unavailable": "This content is unavailable.",
+    "pause": "Pause",
+    "card.tag.album": "Album",
+    "card.tag.track": "Song",
+    "card.tag.artist": "Artist",
+    "card.tag.episode": "Episode",
+    "card.tag.show": "Podcast",
+    "card.tag.playlist": "Playlist",
+    "ad-formats.exclusive": "spotify exclusive",
+    "ad-formats.presentedBy": "Presented By",
+    "download.download": "Download",
+    "download.upsell": "Unlock downloads and other features with Premium",
+    "download.remove": "Remove download",
+    "download.cancel": "Cancel download",
+    "playlist.similar-playlist": "Similar playlist",
+    "playlist.curation.title": "Let's find something for your playlist",
+    "playlist.curation.search_placeholder": "Search for songs or episodes",
+    "navbar.go-back": "Go back",
+    "playlist.remove_from_playlist": "Remove from '{0}'",
+    "more": "More",
+    "playlist.extender.recommended.title": "Recommended",
+    "playlist.extender.songs.in.playlist": "Based on what's in this playlist",
+    "playlist.extender.refresh": "Refresh",
+    "enhance.button_aria_label_enhanced": "Turn off Enhance",
+    "enhance.button_aria_label_not_enhanced": "Turn on Enhance",
+    "enhance.button_text_enhanced": "Enhanced",
+    "enhance.button_text_not_enhanced": "Enhance",
+    "contextmenu.go-to-playlist-radio": "Go to playlist radio",
+    "contextmenu.create-similar-playlist": "Create similar playlist",
+    "contextmenu.share.copy-playlist-link": "Copy link to playlist",
+    "desktop.settings.streamingQualityAutomatic": "Automatic",
+    "desktop.settings.streamingQualityLow": "Low",
+    "desktop.settings.streamingQualityNormal": "Normal",
+    "desktop.settings.streamingQualityHigh": "High",
+    "desktop.settings.streamingQualityVeryHigh": "Very high",
+    "desktop.settings.streamingQualityHiFi": "HiFi",
+    "desktop.settings.loudnessLoud": "Loud",
+    "desktop.settings.loudnessNormal": "Normal",
+    "desktop.settings.loudnessQuiet": "Quiet",
+    "desktop.settings.musicQuality": "Audio quality",
+    "desktop.settings.streamingQuality": "Streaming quality",
+    "desktop.settings.downloadQuality.title": "Download",
+    "desktop.settings.downloadQuality.info": "Higher quality uses more storage.",
+    "desktop.settings.automatic-downgrade.title": "Auto adjust quality - Recommended setting: On",
+    "desktop.settings.automatic-downgrade.info": "We adjust your audio quality when your internet bandwidth is slow. Turning this off may cause interruptions to your listening.",
+    "desktop.settings.normalize": "Normalize volume - Set the same volume level for all songs and podcasts",
+    "desktop.settings.loudnessEnvironment_with_limiter_details": "Volume level - Adjust the volume for your environment. Loud may diminish audio quality. No effect on audio quality in Normal or Quiet.",
+    "desktop.settings.autoplay": "Autoplay",
+    "desktop.settings.autoplayInfo": "Autoplay similar songs when your music ends",
+    "desktop.settings.explicitContentFilter": "Explicit content",
+    "desktop.settings.explicitContentFilterSettingLocked": "Explicit content can't be played on this Family account",
+    "desktop.settings.explicitContentFilterSetting": "Allow playback of explicit-rated content",
+    "settings.localFiles": "Local Files",
+    "settings.showLocalFiles": "Show Local Files",
+    "settings.display": "Display",
+    "settings.showMusicAnnouncements": "Show announcements about new releases",
+    "settings.showTrackNotifications": "Show desktop notifications when the song changes",
+    "desktop.settings.showSystemMediaControls": "Show desktop overlay when using media keys",
+    "buddy-feed.see-what-your-friends-are-playing": "See what your friends are playing",
+    "desktop.settings.language": "Language",
+    "desktop.settings.selectLanguage": "Choose language - Changes will be applied after restarting the app",
+    "settings.restartApp": "Restart App",
+    "desktop.settings.social": "Social",
+    "desktop.settings.facebook": "Connect with Facebook to see what your friends are playing.",
+    "desktop.settings.facebook.disconnect": "Disconnect from Facebook",
+    "desktop.settings.facebook.connect": "Connect with Facebook",
+    "desktop.settings.newPlaylistsPublic": "Make my new playlists public",
+    "desktop.settings.privateSession": "Start a private session to listen anonymously",
+    "desktop.settings.publishActivity": "Share my listening activity on Spotify",
+    "desktop.settings.publishTopArtists": "Show my recently played artists on my public profile",
+    "playlist-radio.more-songs": "More songs load as you listen",
+    "settings.employee": "Employee only",
+    "desktop.settings.enableDeveloperMode": "Enable developer mode",
+    "desktop.settings.autostartMinimized": "Minimized",
+    "desktop.settings.autostartNormal": "Yes",
+    "desktop.settings.autostartOff": "No",
+    "desktop.settings.sec": "sec",
+    "desktop.settings.playback": "Playback",
+    "desktop.settings.crossfadeTracks": "Crossfade songs",
+    "desktop.settings.automixInfo": "Allow smooth transitions between songs in a playlist",
+    "desktop.settings.monoDownmixer": "Mono audio - Makes the left and right speakers play the same audio",
+    "desktop.settings.startupAndWindowBehavior": "Startup and window behaviour",
+    "desktop.settings.autostart": "Open Spotify automatically after you log into the computer",
+    "desktop.settings.closeShouldMinimize": "Close button should minimize the Spotify window",
+    "desktop.settings.compatibility": "Compatibility",
+    "desktop.settings.enableHardwareAcceleration": "Enable hardware acceleration",
+    "desktop.settings.privacy": "Privacy",
+    "desktop.settings.cookiesDisabled": "Block all cookies for this installation of the Spotify desktop app; read more details in the <a class=\"settings__cookiesDiabled-link\" href=\"https://www.spotify.com/legal/privacy-policy/\">privacy policy</a>. Please note that enabling this setting may negatively impact your Spotify experience. Changes will be applied after restarting the app",
+    "search.playlist-by": "By {0}",
+    "tracklist-header.songs-counter": {
+        "one": "{0} song",
+        "other": "{0} songs"
+    },
+    "tracklist-header.episodes-counter": {
+        "one": "{0} episode",
+        "other": "{0} episodes"
+    },
+    "context-menu.copy-episode-link": "Copy Episode Link",
+    "show_less": "Show less",
+    "music_and_talk.in_this_episode": "In this episode",
+    "context-menu.copy-show-link": "Copy Show Link",
+    "mwp.entity.might.like": "You might also like",
+    "type.newEpisode": "New episode",
+    "type.newPodcastEpisode": "New Podcast Episode",
+    "age.restriction.nineeteen-badge": "Nineteen plus content",
+    "playlist.default_playlist_name": "New Playlist",
+    "playlist.new-default-name": "My Playlist #{0}",
+    "episode.played": "Played",
+    "track-trailer": "Trailer",
+    "following": "Following",
+    "follow": "Follow",
+    "concert.error.no_locations_found_subtitle": "We could not find the location you're looking for.",
+    "concert.error.general_error_title": "There was an error requesting data.",
+    "concerts_shows_in": "Shows in",
+    "concerts.input.search_placeholder": "Search by city",
+    "podcasts": "Podcasts",
+    "artists": "Artists",
+    "albums": "Albums",
+    "sidebar.liked_songs": "Liked Songs",
+    "collection.filter.albums": "Search in albums",
+    "error.request-collection-albums-failure": "Something went wrong while loading your albums.",
+    "collection.empty-page.albums-cta": "Find albums",
+    "collection.empty-page.albums-subtitle": "Save albums by tapping the heart icon.",
+    "collection.empty-page.albums-title": "Follow your first album",
+    "collection.filter.podcasts": "Search in podcasts",
+    "error.request-collection-shows-failure": "Something went wrong while loading your podcasts.",
+    "collection.empty-page.shows-subtitle": "Follow podcasts you like by tapping the follow button.",
+    "collection.empty-page.shows-title": "Follow your first podcast",
+    "collection.filter.artists": "Search in artists",
+    "error.request-collection-artists-failure": "Something went wrong while loading your artists.",
+    "collection.empty-page.artists-subtitle": "Follow artists you like by tapping the follow button.",
+    "collection.empty-page.artists-title": "Follow your first artist",
+    "collection.empty-page.artists-cta": "Find artists",
+    "collection.filter.playlists": "Search in playlists",
+    "collection.empty-page.playlists-cta": "Create playlist",
+    "collection.empty-page.playlists-title": "Create your first playlist",
+    "collection.empty-page.playlists-subtitle": "It's easy, we'll help you.",
+    "error.request-collection-music-downloads-failure": "Something went wrong while loading your downloaded music.",
+    "remove_from_your_liked_songs": "Remove from your Liked Songs",
+    "sidebar.your_episodes": "Your Episodes",
+    "concert.header.partner_songkick_attribution": "Available on {0}",
+    "concert.header.partner_price_attribution": "From {0} on {1}",
+    "concert.header.partner_attribution": "Sold on {0}",
+    "concert_available_through": "Available through {0}",
+    "concert_find_virtual_event": "Find Virtual Event",
+    "concert.button.see_tickets": "Find Tickets",
+    "concert_event_ended": "Event ended",
+    "concert_past_message": "Check out more upcoming events for more recommendations",
+    "concert_lineup": "The lineup",
+    "concerts_more_events": "More events you might like",
+    "track-page.popular-singles-and-eps-by-artist": "Popular Singles and EPs by %artist%",
+    "track-page.popular-albums-by-artist": "Popular Albums by %artist%",
+    "track-page.popular-releases-by-artist": "Popular Releases by %artist%",
+    "track-page.popular-tracks": "Popular Tracks by",
+    "contextmenu.go-to-song-radio": "Go to song radio",
+    "contextmenu.show-credits": "Show credits",
+    "context-menu.copy-track-link": "Copy Song Link",
+    "collection.sort.recently-played": "Recently played",
+    "collection.sort.recently-added": "Recently added",
+    "collection.sort.alphabetical": "Alphabetical",
+    "collection.sort.creator": "Creator",
+    "collection.sort.most-relevant": "Most relevant",
+    "collection.sort.custom-order": "Custom order",
+    "sort.custom-order": "Custom order",
+    "sort.title": "Title",
+    "sort.artist": "Artist",
+    "sort.added-by": "Added by",
+    "sort.date-added": "Date added",
+    "sort.duration": "Duration",
+    "sort.album": "Album",
+    "sort.album-or-podcast": "Album or podcast",
+    "artist.latest-release": "Latest Release",
+    "contextmenu.go-to-artist-radio": "Go to artist radio",
+    "context-menu.copy-album-link": "Copy Album Link",
+    "queue.page-title": "Spotify – Play Queue",
+    "playback-control.queue": "Queue",
+    "queue.now-playing": "Now playing",
+    "queue.next-in-queue": "Next in queue",
+    "queue.next-from": "Next from:",
+    "queue.next-up": "Next up",
+    "error.request-artist-featuring": "Something went wrong while loading playlists featuring this artist.",
+    "artist-page.featuring.seo.title": "Featuring {0}",
+    "artist-page.featuring": "Featuring {0}",
+    "artist.popular-tracks": "Popular",
+    "artist-page.on-tour": "On tour",
+    "artist-page.offers": "Offers",
+    "artist-page.popular": "Popular releases",
+    "artist.albums": "Albums",
+    "artist.singles": "Singles and EPs",
+    "artist.compilations": "Compilations",
+    "artist-page.fansalsolike": "Fans also like",
+    "artist.appears-on": "Appears On",
+    "artist-page.artist-playlists": "Artist Playlists",
+    "artist-page.discovered-on": "Discovered on",
+    "error.request-related-artists": "Something went wrong while loading related artists.",
+    "artist-page.fansalsolike.seo.title": "Artists Fans of {0} also like",
+    "error.request-artist-appears-on": "Something went wrong while loading releases this artist appears on.",
+    "artist-page.appearson.seo.title": "Releases {0} appears on",
+    "error.request-artist-playlists": "Something went wrong while loading the artist's playlists.",
+    "artist-page.artist-playlists.seo.title": "Playlists by {0}",
+    "artist-page.liked-songs-by-artist-title": "Liked Songs by {0}",
+    "lyrics.providedBy": "Lyrics provided by {0}",
+    "lyrics.unsynced": "These lyrics aren't synced to the song yet.",
+    "lyrics.noLyrics0": "Hmm. We don't know the lyrics for this one.",
+    "lyrics.noLyrics1": "Looks like we don't have the lyrics for this song.",
+    "lyrics.noLyrics2": "You caught us, we're still working on getting lyrics for this one.",
+    "lyrics.noLyrics3": "You'll have to guess the lyrics for this one.",
+    "lyrics.ad": "Lyrics will show after the audio ad",
+    "lyrics.error": "Couldn't load the lyrics for this song. Try again later.",
+    "action-trigger.save-album": "Log in to save this album to Your Library.",
+    "singalong.off": "Off",
+    "singalong.more-vocal": "More Vocal",
+    "singalong.less-vocal": "Less Vocal",
+    "singalong.title": "Sing Along",
+    "singalong.button": "Sing",
+    "card.tag.profile": "Profile",
+    "playlist.edit-details.title": "Edit details",
+    "top_artists_this_month": "Top artists this month",
+    "only_visible_to_you": "Only visible to you",
+    "top_tracks_this_month": "Top tracks this month",
+    "public_playlists": "Public Playlists",
+    "recently_played_artists": "Recently played artists",
+    "followers": "Followers",
+    "error.request-artist-discography": "Something went wrong while loading the artist's discography.",
+    "artist-page.discography.seo.title": "{0} - Discography",
+    "lyrics.title": "Lyrics",
+    "topBar.label": "Top bar and user menu",
+    "navbar.go-forward": "Go forward",
+    "sign_up": "Sign up",
+    "download.progress-global": "{0}/{1}",
+    "navbar.search.callout-title": "Search is always one click away",
+    "navbar.search.callout-description": "Find your favorite artists, podcasts, or songs.",
+    "connect-bar.listening-state": "Listening on %device_name%",
+    "connect-bar.connecting-state": "Connecting to %device_name%",
+    "playback-control.a11y.landmark-label": "Player controls",
+    "my.headline": "Try Premium free for 3 months. Listen to your music offline and ad-free. Monthly subscription fee applies after. Open only to users who haven't already tried Premium. Offer excludes Family and Duo plans. <a href=\"%help_link%\">Terms and conditions apply</a>.",
+    "fta.bottom-bar.subtitle": "Sign up to get unlimited songs and podcasts with occasional ads. No credit card needed.",
+    "fta.sign-up-free": "Sign up free",
+    "pta.bottom-bar.title": "Preview of Spotify",
+    "fta.bottom-bar.subtitle-two": "Listen to local favorites and the world’s best playlists.",
+    "playback-control.ban": "Remove",
+    "video-player.show-video": "Show video",
+    "video-player.hide-video": "Hide video",
+    "playlist.new-header": "Create new playlist",
+    "keyboard.shortcuts.description.createNewFolder": "Create new folder",
+    "keyboard.shortcuts.description.openContextMenu": "Open context menu",
+    "keyboard.shortcuts.description.selectAll": "Select all",
+    "filter": "Filter",
+    "keyboard.shortcuts.description.togglePlay": "Play / Pause",
+    "keyboard.shortcuts.description.likeDislikeSong": "Like",
+    "keyboard.shortcuts.description.shuffle": "Shuffle",
+    "keyboard.shortcuts.description.repeat": "Repeat",
+    "keyboard.shortcuts.description.skipPrev": "Skip to previous",
+    "keyboard.shortcuts.description.skipNext": "Skip to next",
+    "keyboard.shortcuts.description.seekBackward": "Seek backward",
+    "keyboard.shortcuts.description.seekForward": "Seek forward",
+    "keyboard.shortcuts.description.raiseVolume": "Raise volume",
+    "keyboard.shortcuts.description.lowerVolume": "Lower volume",
+    "keyboard.shortcuts.description.home": "Home",
+    "keyboard.shortcuts.description.goBackwards": "Back in history",
+    "keyboard.shortcuts.description.goForwards": "Forward in history",
+    "keyboard.shortcuts.description.goToPreferences": "Preferences",
+    "keyboard.shortcuts.description.currentlyPlaying": "Currently playing",
+    "keyboard.shortcuts.description.search": "Search",
+    "keyboard.shortcuts.description.likedSongs": "Liked songs",
+    "keyboard.shortcuts.description.yourPlaylists": "Your playlists",
+    "keyboard.shortcuts.description.yourPodcasts": "Your podcasts",
+    "keyboard.shortcuts.description.yourArtists": "Your artists",
+    "keyboard.shortcuts.description.yourAlbums": "Your albums",
+    "keyboard.shortcuts.description.madeForYour": "Made for you",
+    "new_releases": "New Releases",
+    "keyboard.shortcuts.description.charts": "Charts",
+    "keyboard.shortcuts.layout.navigationBarDecreaseWidth": "Decrease navigation bar width",
+    "keyboard.shortcuts.layout.navigationBarIncreaseWidth": "Increase navigation bar width",
+    "keyboard.shortcuts.layout.friendFeedDecreaseWidth": "Decrease friend activity width",
+    "keyboard.shortcuts.layout.friendFeedIncreaseWidth": "Increase friend activity width",
+    "track-credits.performers": "Performed by",
+    "track-credits.writers": "Written by",
+    "track-credits.producers": "Produced by",
+    "track-credits.assistant-recording-engineer": "Assistant recording engineer",
+    "track-credits.engineer": "Engineer",
+    "track-credits.assistant-engineer": "Assistant engineer",
+    "track-credits.trumpet": "Trumpet",
+    "track-credits.guitar": "Guitar",
+    "track-credits.composer-and-lyricist": "Composer and lyricist",
+    "track-credits.associated-performer": "Associated performer",
+    "track-credits.background-vocals": "Background vocals",
+    "track-credits.bass": "Bass",
+    "track-credits.co-producer": "Co-producer",
+    "track-credits.additional-engineer": "Additional engineer",
+    "track-credits.masterer": "Masterer",
+    "track-credits.mixer": "Mixer",
+    "track-credits.recording-engineer": "Recording engineer",
+    "track-credits.accordion": "Accordion",
+    "track-credits.piano": "Piano",
+    "track-credits.organ": "Organ",
+    "track-credits.mixing-engineer": "Mixing engineer",
+    "track-credits.editor": "Editor",
+    "track-credits.fiddle": "Fiddle",
+    "track-credits.additional-vocals": "Additional vocals",
+    "track-credits.violin": "Violin",
+    "track-credits.viola": "Viola",
+    "track-credits.percussion": "Percussion",
+    "track-credits.mastering-engineer": "Mastering engineer",
+    "track-credits.composer": "Composer",
+    "track-credits.additional-keyboards": "Additional keyboards",
+    "track-credits.mix-engineer": "Mix engineer",
+    "track-credits.mandolin": "Mandolin",
+    "track-credits.acoustic-guitar": "Acoustic guitar",
+    "track-credits.keyboards": "Keyboards",
+    "track-credits.synthesizer": "Synthesizer",
+    "track-credits.programmer": "Programmer",
+    "track-credits.assistant-mixer": "Assistant mixer",
+    "track-credits.assistant-mixing-engineer": "Assistant mixing engineer",
+    "track-credits.digital-editor": "Digital editor",
+    "track-credits.drums": "Drums",
+    "track-credits.drum-programming": "Drum programming",
+    "track-credits.conga": "Conga",
+    "track-credits.samples": "Samples",
+    "track-credits.audio-recording-engineer": "Audio recording engineer",
+    "track-credits.audio-additional-mix-engineer": "Audio additional mix engineer",
+    "track-credits.recording": "Recording",
+    "track-credits.assistant-producer": "Assistant producer",
+    "track-credits.writer": "Writer",
+    "track-credits.strings": "Strings",
+    "track-credits.music-publisher": "Music publisher",
+    "track-credits.programming": "Programming",
+    "track-credits.music-production": "Music production",
+    "track-credits.background-vocalist": "Background vocalist",
+    "track-credits.producer": "Producer",
+    "track-credits.vocal": "Vocal",
+    "track-credits.songwriter": "Songwriter",
+    "track-credits.lyricist": "Lyricist",
+    "track-credits.additional-mixer": "Additional mixer",
+    "track-credits.upright-bass": "Upright bass",
+    "track-credits.clapping": "Clapping",
+    "track-credits.electric-bass": "Electric bass",
+    "track-credits.horn-arranger": "Horn arranger",
+    "track-credits.flugelhorn": "Flugelhorn",
+    "track-credits.second-engineer": "Second engineer",
+    "track-credits.rhythm-guitar": "Rhythm guitar",
+    "track-credits.bass-guitar": "Bass guitar",
+    "track-credits.electric-guitar": "Electric guitar",
+    "track-credits.dobro": "Dobro",
+    "track-credits.instruments": "Instruments",
+    "track-credits.recording-arranger": "Recording arranger",
+    "track-credits.arranger": "Arranger",
+    "track-credits.steel-guitar": "Steel guitar",
+    "track-credits.executive-producer": "Executive producer",
+    "track-credits.additional-production": "Additional production",
+    "track-credits.designer": "Designer",
+    "track-credits.assistant-mix-engineer": "Assistant mix engineer",
+    "track-credits.studio-musician": "Studio musician",
+    "track-credits.voice-performer": "Voice performer",
+    "track-credits.orchestra": "Orchestra",
+    "track-credits.chamber-ensemble": "Chamber ensemble",
+    "track-credits.additional-percussion": "Additional percussion",
+    "track-credits.cajon": "Cajon",
+    "track-credits.miscellaneous-production": "Miscellaneous production",
+    "track-credits.pedal-steel": "Pedal steel",
+    "track-credits.additional-producer": "Additional producer",
+    "track-credits.keyboards-arrangements": "Keyboard arrangements",
+    "track-credits.saxophone": "Saxophone",
+    "track-credits.sound-engineer": "Sound engineer",
+    "track-credits.assistant-remix-engineer": "Assistant remix engineer",
+    "track-credits.double-bass": "Double bass",
+    "track-credits.co-writer": "Co-writer",
+    "track-credits.pro-tools": "Pro Tools",
+    "track-credits.tape-realization": "Tape realization",
+    "track-credits.ambient-sounds": "Ambient sounds",
+    "track-credits.sound-effects": "Sound effects",
+    "track-credits.harp": "Harp",
+    "track-credits.cymbals": "Cymbals",
+    "track-credits.vocal-engineer": "Vocal engineer",
+    "track-credits.mellotron": "Mellotron",
+    "track-credits.recorder": "Recorder",
+    "track-credits.main-artist": "Main artist",
+    "track-credits.production": "Production",
+    "track-credits.artist": "Artist",
+    "track-credits.vocals": "Vocals",
+    "track-credits.featuring": "Featuring",
+    "track-credits.featured-artist": "Featured artist",
+    "track-credits.work-arranger": "Work arranger",
+    "track-credits.mixing-engineers": "Mixing engineers",
+    "track-credits.re-mixer": "Re-mixer",
+    "track-credits.recording-producer": "Recording producer",
+    "track-credits.co-mixer": "Co-mixer",
+    "track-credits.bells": "Bells",
+    "track-credits.pro-tools-editing": "Pro Tools editing",
+    "track-credits.vibraphone": "Vibraphone",
+    "track-credits.additional-recording": "Additional recording",
+    "track-credits.vocal-producer": "Vocal producer",
+    "track-credits.sitar": "Sitar",
+    "track-credits.cello": "Cello",
+    "track-credits.flute": "Flute",
+    "track-credits.horn": "Horn",
+    "track-credits.brass-band": "Brass band",
+    "track-credits.programming-and-keyboards": "Programming and keyboards",
+    "track-credits.all-instruments": "All instruments",
+    "track-credits.programmed-and-arranged-by": "Programmed and arranged by",
+    "track-credits.additional-programmer": "Additional programmer",
+    "track-credits.recording-and-mixing": "Recording and mixing",
+    "track-credits.engineer-and-mixer": "Engineer and mixer",
+    "track-credits.vocal-arranger": "Vocal arranger",
+    "track-credits.income-participant": "Income participant",
+    "playlist.default_folder_name": "New Folder",
+    "keyboard.shortcuts.or": "or",
+    "buddy-feed.friend-activity": "Friend Activity",
+    "buddy-feed.add-friends": "Add Friends",
+    "save": "Save",
+    "image-upload.legal-disclaimer": "By proceeding, you agree to give Spotify access to the image you choose to upload. Please make sure you have the right to upload the image.",
+    "about.title_label": "About Spotify",
+    "about.copyright": "Copyright &copy; {0} Spotify AB.<br/>Spotify® is a registered trademark of the Spotify Group.",
+    "shows.filter.unplayed": "Unplayed",
+    "shows.filter.in-progress": "In Progress",
+    "shows.sort.newest-to-oldest": "Newest to Oldest",
+    "shows.sort.oldest-to-newest": "Oldest to Newest",
+    "shows.sort.longest-to-shortest": "Longest to Shortest",
+    "shows.sort.shortest-to-longest": "Shortest to Longest",
+    "user.public-playlists": {
+        "one": "{0} Public Playlist",
+        "other": "{0} Public Playlists"
+    },
+    "user.private-playlists": {
+        "one": "{0} Private Playlist",
+        "other": "{0} Private Playlists"
+    },
+    "likes": {
+        "one": "{0} like",
+        "other": "{0} likes"
+    },
+    "user.followers": {
+        "one": "{0} Follower",
+        "other": "{0} Followers"
+    },
+    "user.following": {
+        "one": "{0} Following",
+        "other": "{0} Following"
+    },
+    "chart.new-entries": {
+        "one": "{0} new entry",
+        "other": "{0} new entries"
+    },
+    "wrapped.eligible-description": "Your 2020 Wrapped is ready. Download the Spotify mobile app to see it. Or,",
+    "wrapped.eligible-activation-cta": "see how the world listened here.",
+    "wrapped.ineligible-description-wo-podcasts": "See the songs and artists that got us all through 2020. Then keep listening on Spotify to get your own Wrapped next year.",
+    "wrapped.ineligible-description": "See the songs, artists, and podcasts that got us all through 2020. Then keep listening on Spotify to get your own Wrapped next year.",
+    "wrapped.explore-cta": "Explore Wrapped",
+    "playlist.header.made-for": "Made for {0}",
+    "search.title.artists": "Artists",
+    "search.title.albums": "Albums",
+    "search.title.playlists": "Playlists",
+    "search.title.shows": "Podcasts",
+    "search.title.episodes": "Episodes",
+    "search.title.profiles": "Profiles",
+    "search.title.genres": "Genres",
+    "search.title.tracks": "Songs",
+    "search.title.top-result": "Top result",
+    "search.showing-category-query-songs": "All songs for “{0}”",
+    "download.downloading": "Downloading {0} tracks",
+    "download.complete": "Download complete",
+    "ad-formats.hideAnnouncements": "Hide Announcements",
+    "ad-formats.sponsored": "Sponsored",
+    "ad-formats.remove": "Remove",
+    "ad-formats.save": "Save",
+    "unfollow": "Unfollow",
+    "episode.sponsored_by": "Sponsored By",
+    "episode.sponsors": "Episode Sponsors",
+    "playlist.curation.see_all_artists": "See all artists",
+    "playlist.curation.see_all_album": "See all albums",
+    "playlist.curation.see_all_songs": "See all songs",
+    "tracklist.drag.multiple.label": {
+        "one": "{0} item",
+        "other": "{0} items"
+    },
+    "playlist.remove_multiple_description": "You’ll need to add them again if you change your mind.",
+    "remove": "Remove",
+    "choose_photo": "Choose photo",
+    "contextmenu.share": "Share",
+    "settings.localFilesFolderAdded": "Folder added. Now showing songs from {0}",
+    "settings.showSongsFrom": "Show songs from",
+    "settings.addASource": "Add a source",
+    "card.tag.genre": "Genre",
+    "contextmenu.add-to-playlist": "Add to playlist",
+    "episode.length": "{0} min",
+    "desktop.settings.proxy.title": "Proxy Settings",
+    "desktop.settings.proxy.type": "Proxy type",
+    "desktop.settings.proxy.host": "Host",
+    "desktop.settings.proxy.port": "Port",
+    "desktop.settings.proxy.user": "Username",
+    "desktop.settings.proxy.pass": "Password",
+    "contextmenu.share.copy-artist-link": "Copy link to artist",
+    "card.a11y.explicit": "Explicit",
+    "desktop.settings.offlineStorageLocation": "Offline storage location",
+    "desktop.settings.offlineStorageChangeLocation": "Change location",
+    "mwp.see.more": "see more",
+    "action-trigger.available-in-app-only": "Available only in the app",
+    "action-trigger.listen-mixed-media-episode": "You can listen to this episode right now in the Spotify app.",
+    "action-trigger.button.get-app": "Get App",
+    "paywalls.modal-heading": "Support this podcast and get access to all episodes",
+    "paywalls.modal-body-p1": "By supporting this creator with a monthly subscription, you’ll help them to make more episodes.",
+    "paywalls.modal-body-p2": "You’ll get exclusive access to their show feed, including any bonus episodes the creator releases.",
+    "paywalls.modal-body-p3": "Go to the show notes, or visit the creator’s site for more information.",
+    "concert.header.entity_title_1": "{0}",
+    "concert.header.entity_title_2": "{0} with {1}",
+    "concert.header.entity_title_3": "{0} with {1} and {2}",
+    "concert.header.entity_title_4": "{0} with {1}, {2} and {3}",
+    "concert.header.entity_title_more": "{0} with {1}, {2}, {3} and {4} more...",
+    "concert.header.upcoming_concert_title_1": "{0}",
+    "concert.header.upcoming_concert_title_2": "{0} & {1}",
+    "concert.header.upcoming_concert_title_3": "{0}, {1} & {2}",
+    "concert.header.upcoming_concert_title_4": "{0}, {1}, {2} & {3}",
+    "concert.header.upcoming_concert_title_more": "{0}, {1}, {2}, and {3} more...",
+    "more.label.track": "More options for {0} by {1}",
+    "concert.label.headliner": "Headliner",
+    "concerts_browse_more": "Browse more concerts",
+    "tracklist.popular-tracks": "popular tracks",
+    "artist-page.tracks.showless": "Show less",
+    "artist-page.tracks.seemore": "See more",
+    "contextmenu.go-to-artist": "Go to artist",
+    "context-menu.copy-concert-link": "Copy Concert link",
+    "track-page.from-the-single": "From the single",
+    "track-page.from-the-ep": "From the Ep",
+    "track-page.from-the-compilation": "From the compilation",
+    "track-page.from-the-album": "From the album",
+    "history.empty-title": "See what you've listened to",
+    "history.empty-description": "Your listening history will appear here",
+    "queue.empty-title": "Add to your queue",
+    "queue.empty-description": "Tap \"Add to queue\" from a track's menu to see it here",
+    "queue.fine-something": "Find something to play",
+    "queue.clear-queue": "Clear queue",
+    "queue.confirm-title": {
+        "one": "Clear this from your queue?",
+        "other": "Clear these from your queue?"
+    },
+    "queue.confirm-message": "This cannot be undone",
+    "queue.cancel-button": "Cancel",
+    "queue.confirm-button": "Yes",
+    "artist.monthly-listeners-count": {
+        "one": "{0} monthly listener",
+        "other": "{0} monthly listeners"
+    },
+    "artist": "Artist",
+    "acq.artist.about.attribution": "Posted By %artist%",
+    "artist-page.artists-pick": "Artist pick",
+    "artist-page.world_rank": "in the world",
+    "monthly_listeners": "Monthly Listeners",
+    "artist-page.where-people-listen-from": "{0}, {1}",
+    "artist-page.how-many-listeners": {
+        "one": "{0} listener",
+        "other": "{0} listeners"
+    },
+    "view.see-all": "See all",
+    "artist-page.saved-header": "Liked Songs",
+    "artist-page.saved-tracks-amount": {
+        "one": "You've liked {0} song",
+        "other": "You've liked {0} songs"
+    },
+    "artist-page.saved-by-artist": "By {0}",
+    "artist.concerts.error.not_found": "This artist has no concert listings.",
+    "concerts.header.other": "Other Locations",
+    "contextmenu.share.copy-profile-link": "Copy link to profile",
+    "user.edit-details.title": "Profile details",
+    "user.edit-details.name-label": "Name",
+    "user.edit-details.name-placeholder": "Add a display name",
+    "browse.made-for-you": "Made For You",
+    "browse.charts": "Charts",
+    "browse.discover": "DISCOVER",
+    "browse.podcasts": "PODCASTS",
+    "playback-control.skip-back": "Previous",
+    "playback-control.skip-forward": "Next",
+    "private-session.callout": "You’re listening anonymously in a private session.",
+    "private-session.badge": "Private session",
+    "offline.callout-disconnected": "Make sure you're online. Spotify works best with an internet connection.",
+    "offline.badge": "You're offline",
+    "cookies": "Cookies",
+    "privacy": "Privacy",
+    "upgrade.tooltip.title": "Upgrade to Premium",
+    "navbar.install-app": "Install App",
+    "upgrade.button": "Upgrade",
+    "user.update-available": "Update available",
+    "npb.collapseCoverArt": "Collapse",
+    "npb.expandVideo": "Expand Video",
+    "fta.wall.start-listening": "Start listening with a free Spotify account",
+    "fta.wall.start-watching": "Listen and watch with a free Spotify account",
+    "mwp.cta.sign.up.free": "SIGN UP FREE",
+    "mwp.cta.download.app": "DOWNLOAD APP",
+    "already_have_account": "Already have an account?",
+    "playback-control.unmute": "Unmute",
+    "playback-control.mute": "Mute",
+    "playback-control.a11y.volume-slider-button": "Change volume",
+    "npv.full-screen": "Full screen",
+    "sidebar.playlist_create": "Create Playlist",
+    "playback-control.a11y.seek-slider-button": "Change progress",
+    "playback-control.disable-shuffle": "Disable shuffle",
+    "playback-control.enable-shuffle": "Enable shuffle",
+    "playback-control.play": "Play",
+    "playback-control.pause": "Pause",
+    "playback-control.skip-backward-15": "Skip back 15 seconds",
+    "playback-control.skip-forward-15": "Skip forward 15 seconds",
+    "playback-control.disable-repeat": "Disable repeat",
+    "playback-control.enable-repeat": "Enable repeat",
+    "playback-control.enable-repeat-one": "Enable repeat one",
+    "playback-control.change-playback-speed": "Change speed",
+    "npb.expandCoverArt": "Expand",
+    "playback-control.now-playing-label": "Now playing: {0} by {1}",
+    "age.restriction.explicitContent": "You need to be at least 19 years old to listen to explicit content marked with",
+    "age.restriction.continue": "Continue",
+    "npv.exit-full-screen": "Exit full screen",
+    "buddy-feed.button.back": "Back",
+    "buddy-feed.facebook.connect-with-friends-default": "Connect with Facebook to see what your friends are playing.",
+    "buddy-feed.facebook.button": "Connect with Facebook",
+    "buddy-feed.facebook.disclaimer": "We’ll never post anything without your permission. Show and hide Friend Activity from Settings.",
+    "licenses.title": "Third-party licenses",
+    "playlist.edit-details.error.description-breaks": "Line breaks aren't supported in the description.",
+    "playlist.edit-details.error.invalid-html": "HTML isn't supported in playlist description.",
+    "playlist.edit-details.error.unsaved-changes": "Press save to keep changes you've made.",
+    "playlist.edit-details.error.no-internet": "No internet connection found. Changes to description and image will not be saved.",
+    "playlist.edit-details.error.file-size-exceeded": "Image too large. Please select an image below 4MB.",
+    "playlist.edit-details.error.too-small": "Image too small. Images must be at least {0}x{1}.",
+    "playlist.edit-details.error.file-upload-failed": "Failed to upload image. Please try again.",
+    "playlist.edit-details.error.missing-name": "Playlist name is required.",
+    "playlist.edit-details.error.failed-to-save": "Failed to save playlist changes. Please try again.",
+    "playlist.edit-details.description-label": "Description",
+    "playlist.edit-details.description-placeholder": "Add an optional description",
+    "playlist.edit-details.name-label": "Name",
+    "playlist.edit-details.name-placeholder": "Add a name",
+    "playlist.edit-details.change-photo": "Change photo",
+    "playlist.edit-details.remove-photo": "Remove photo",
+    "edit_photo": "Edit photo",
+    "video-player.default-view": "Default view",
+    "video-player.cinema-mode": "Cinema mode",
+    "subtitles-picker.heading": "Subtitles",
+    "about.upgrade.pending": "A new version of Spotify is available ({0}).",
+    "about.upgrade.pending_link": "Click here to download.",
+    "about.upgrade.downloading": "Downloading a new version of Spotify...",
+    "about.upgrade.downloaded": "Spotify has been updated to version {0}.",
+    "about.upgrade.restart_link": "Please restart to install.",
+    "desktop-about.platform-win-x86": "Windows",
+    "desktop-about.platform-win-arm-64": "Windows (ARM64)",
+    "desktop-about.platform-mac-x86": "macOS (Intel)",
+    "desktop-about.platform-mac-arm-64": "macOS (Apple Silicon)",
+    "desktop-about.platform-linux": "Linux",
+    "desktop-about.platform-unknown": "unknown",
+    "desktop-about.platform": "Spotify %employee_build_type% for %platform%",
+    "desktop-about.copy-version-info-tooltip": "Copy version info",
+    "home.evening": "Good evening",
+    "home.morning": "Good morning",
+    "home.afternoon": "Good afternoon",
+    "search.a11y.songs-search-results": "Songs search results",
+    "search.see-all": "See all",
+    "playlist.presented_by": "Presented By {0}",
+    "context-menu.copy-generic-link": "Copy Link",
+    "contextmenu.go-to-album": "Go to album",
+    "context-menu.episode-page-link": "See Episode Description",
+    "contextmenu.go-to-playlist": "Go to playlist",
+    "context-menu.copy-spotify-uri": "Copy Spotify URI",
+    "contextmenu.report": "Report",
+    "contextmenu.open_desktop_app": "Open in Desktop app",
+    "save_to_your_liked_songs": "Save to your Liked Songs",
+    "contextmenu.remove-from-your-episodes": "Remove from Your Episodes",
+    "contextmenu.save-to-your-episodes": "Save to Your Episodes",
+    "contextmenu.remove-from-library": "Remove from Your Library",
+    "contextmenu.add-to-library": "Add to Your Library",
+    "contextmenu.remove-from-queue": "Remove from queue",
+    "contextmenu.add-to-queue": "Add to queue",
+    "contextmenu.make-secret": "Remove from profile",
+    "contextmenu.make-public": "Add to profile",
+    "contextmenu.delete": "Delete",
+    "contextmenu.edit-details": "Edit details",
+    "contextmenu.collaborative": "Collaborative playlist",
+    "contextmenu.create-folder": "Create folder",
+    "contextmenu.remove-from-playlist": "Remove from this playlist",
+    "contextmenu.create-playlist": "Create playlist",
+    "contextmenu.rename": "Rename",
+    "feedbackmenu.ban-artist-by-name": "I don't like {0}",
+    "feedbackmenu.ban-track": "I don't like this song",
+    "contextmenu.mark-as-unplayed": "Mark as unplayed",
+    "contextmenu.mark-as-played": "Mark as played",
+    "contextmenu.download": "Download",
+    "context-menu.make-playlist-public": "Make public",
+    "context-menu.make-playlist-secret": "Make secret",
+    "local-files.source.downloads": "Downloads",
+    "local-files.source.itunes": "iTunes",
+    "local-files.source.my_music": "My Music",
+    "local-files.source.windows_music_library": "Music Library",
+    "contextmenu.new-playlist": "Add to new playlist",
+    "desktop.settings.proxy.autodetect": "Autodetect settings",
+    "desktop.settings.proxy.noproxy": "No proxy",
+    "desktop.settings.proxy.http": "HTTP",
+    "desktop.settings.proxy.socks4": "SOCKS4",
+    "desktop.settings.proxy.socks5": "SOCKS5",
+    "paid": "Paid",
+    "time.over": "over {0}",
+    "time.estimated": "about {0}",
+    "time.left": "{0} left",
+    "addToPlaylist-icon.label": "Add to Playlist",
+    "playlist.extender.button.add": "Add",
+    "tracklist.disc-sperator.title": "Disc {0}",
+    "artist.verified": "Verified Artist",
+    "gallery.prev": "Previous image",
+    "gallery.next": "Next image",
+    "contextmenu.unblock": "Unblock",
+    "contextmenu.block": "Block",
+    "contextmenu.unfollow": "Unfollow",
+    "contextmenu.follow": "Follow",
+    "contextmenu.edit-profile": "Edit profile",
+    "user.edit-details.error.file-size-exceeded": "Image too large. Please select an image below {0}MB.",
+    "user.edit-details.error.too-small": "Image too small. Images must be at least {0}x{1}.",
+    "user.edit-details.error.missing-name": "Display name is required.",
+    "user.edit-details.error.failed-to-save": "Failed to save profile changes. Please try again.",
+    "user.edit-details.error.file-upload-failed": "Failed to upload image. Please try again.",
+    "user.edit-details.choose-photo": "Choose photo",
+    "user.edit-details.remove-photo": "Remove photo",
+    "playback-control.a11y.volume-off": "Volume off",
+    "playback-control.a11y.volume-low": "Volume low",
+    "playback-control.a11y.volume-medium": "Volume medium",
+    "playback-control.a11y.volume-high": "Volume high",
+    "connect-picker.no-devices-info-top": "Play and control Spotify on all your devices.",
+    "connect-picker.no-devices-info-bottom": "Start Spotify on another device and it will magically appear here.",
+    "connect-picker.learn-more": "Learn more",
+    "connect-picker.picker-title": "Connect to a device",
+    "connect-picker.tooltip": "What is Spotify Connect?",
+    "playback-control.connect-picker": "Connect to a device",
+    "sidebar.expand_folder": "Expand folder",
+    "playback-control.a11y.lightsaber-hilt-button": "Toggle lightsaber hilt. Current is {0}.",
+    "playback-control.playback-speed-button-a11y": "Speed {0}×",
+    "ad-formats.skippable_ads.skip_countdown": "Skip this ad in:",
+    "ad-formats.learnMore": "Learn More",
+    "ad-formats.playTrack": "Play Track",
+    "time.now": "now",
+    "character-counter": "Character counter",
+    "buddy-feed.button.remove-friend": "Remove friend",
+    "buddy-feed.button.add-friend": "Add friend",
+    "buddy-feed.number-of-friends": {
+        "one": "You have {0} friend on Spotify.",
+        "other": "You have {0} friends on Spotify."
+    },
+    "buddy-feed.find-in-playlists": "Filter by name",
+    "subtitles-picker.option_off": "Off",
+    "subtitles-picker.autogenerated": "auto-generated",
+    "subtitles-picker.option_zh": "Chinese",
+    "subtitles-picker.option_cs": "Czech",
+    "subtitles-picker.option_nl": "Dutch",
+    "subtitles-picker.option_en": "English",
+    "subtitles-picker.option_fi": "Finnish",
+    "subtitles-picker.option_fr": "French",
+    "subtitles-picker.option_de": "German",
+    "subtitles-picker.option_el": "Greek",
+    "subtitles-picker.option_hu": "Hungarian",
+    "subtitles-picker.option_id": "Indonesian",
+    "subtitles-picker.option_it": "Italian",
+    "subtitles-picker.option_ja": "Japanese",
+    "subtitles-picker.option_ms": "Malay",
+    "subtitles-picker.option_pl": "Polish",
+    "subtitles-picker.option_pt": "Portuguese",
+    "subtitles-picker.option_es": "Spanish",
+    "subtitles-picker.option_sv": "Swedish",
+    "subtitles-picker.option_tr": "Turkish",
+    "subtitles-picker.option_vi": "Vietnamese",
+    "search.title.top-results": "Top results",
+    "playlist.curation.popular_songs": "Popular songs",
+    "playlist.curation.albums": "Albums",
+    "download.available-offline": "Available offline",
+    "time.hours.short": {
+        "one": "{0} hr",
+        "other": "{0} hr"
+    },
+    "time.minutes.short": {
+        "one": "{0} min",
+        "other": "{0} min"
+    },
+    "time.seconds.short": {
+        "one": "{0} sec",
+        "other": "{0} sec"
+    },
+    "tracklist.header.release-date": "release date",
+    "tracklist.livestream": "livestream",
+    "tracklist.header.title": "title",
+    "tracklist.header.plays": "plays",
+    "tracklist.header.added-by": "added by",
+    "tracklist.header.date-added": "date added",
+    "tracklist.header.event": "event",
+    "tracklist.header.duration": "duration",
+    "tracklist.header.actions": "actions",
+    "tracklist.header.album": "album",
+    "tracklist.header.album-or-podcast": "album or podcast",
+    "music_and_talk.album_or_show": "Album or show",
+    "pwa.download-app": "Download the free app",
+    "user.account": "Account",
+    "employee-podcasts.settings.drop-down": "Get Employee Podcasts",
+    "user.private-session": "Private session",
+    "user.update-client": "Update Spotify now",
+    "user.settings": "Settings",
+    "hifi.songNotAvailableTitle": "Song not available",
+    "hifi.songNotAvailable": "The song you're trying to listen to is not available in HiFi at this time.",
+    "hifi.connectExplanation": "The best way to listen in HiFi is with Spotify Connect. Just play a song, then click {0} at the bottom of the screen to select a {1} compatible device and control your music straight from the app.",
+    "spotify-connect": "Spotify Connect",
+    "hifi.changeCellularSettings": "You set your Settings to play music in Very high or less when streaming. To change this, go to <a href=\"spotify:app:preferences\">Settings</a> and select HiFi for Streaming quality.",
+    "hifi.optOutOfDowngrade": "You’ve disabled the auto-adjust quality feature in Settings. This means you might experience interruptions in your listening experience when you have poor internet bandwidth.",
+    "hifi.poorBandwidthInterferes": "Looks like your internet bandwidth is having a hard time supporting HiFi right now. Try checking your connection or switching to a different network.",
+    "hifi.defaultToVeryHigh": "Nothing is worse than when a song skips right when you’re getting into it. That’s why we automatically adjust you from HiFi to a lower audio quality if your bandwidth is poor.",
+    "hifi.needToReDownload": "The songs you’ve downloaded aren’t currently in HiFi. If you want to listen to them in HiFi, you’ll need to re-download them. Just remember, HiFi song files are big and can take up a lot of storage.",
+    "hifi.bluetoothDegradesHifi": "Listening to HiFi using Bluetooth allows you to enjoy a higher quality of audio than available with Spotify Premium alone. HiFi is best enjoyed over {0} Spotify Connect speakers and/or wired devices.",
+    "playing": "Playing",
+    "time.weeks.short": {
+        "one": "{0} w",
+        "other": "{0} w"
+    },
+    "time.days.short": {
+        "one": "{0} d",
+        "other": "{0} d"
+    },
+    "mwp.list.item.share": "Share",
+    "play-button.label": "PLAY",
+    "pause-button.label": "PAUSE",
+    "connect-picker.this-computer": "This Computer",
+    "connect-picker.this-web-browser": "This Web Browser",
+    "connect-picker.listening-on": "Listening On",
+    "spotify-connect.chromecast": "Google Cast",
+    "connect-picker.unavailable-to-control": "Unavailable to control",
+    "hifi.unknown": "Unknown",
+    "hifi.currentAudioQuality": "Current audio quality:",
+    "hifi.networkConnection": "Network connection",
+    "hifi.good": "Good",
+    "hifi.poor": "Poor",
+    "hifi.hifiCompatibleDevice": "HiFi compatible device",
+    "hifi.yes": "Yes",
+    "hifi.no": "No",
+    "hifi.playingVia": "Playing via",
+    "hifi.internetBandwidth": "Internet bandwidth"
+}</script>
+<script id="features" type="application/json">{
+    "enableShows": true,
+    "isTracingEnabled": false,
+    "upgradeButton": "control",
+    "useEnhancedChromeOSPWACallout": true,
+    "mwp": false,
+    "isMWPErrorCodeEnabled": false,
+    "isMWPQualarooEnabled": false,
+    "isMwpRadioEntity": true,
+    "isMWPAndPlaybackCapable": false,
+    "preauthRecaptcha": false,
+    "isEqualizerABEnabled": false,
+    "isPodcastEnabled": true,
+    "isPodcastSeoEnabled": false,
+    "upgradeOverApp": false,
+    "upgradeOverSignupBanner": false,
+    "musicClips": "0"
+}</script>
+<script id="seo" type="application/json">{
+    "concert": {}
+}</script>
+<script src="https://open.scdn.co/cdn/build/web-player/web-player.82d24d99.js"></script>
+<script src="https://open.scdn.co/cdn/build/web-player/vendor~web-player.615e785f.js"></script>
+<div style="">
+    <div class="grecaptcha-badge" data-style="bottomright"
+         style="width: 256px; height: 60px; position: fixed; visibility: hidden; display: block; transition: right 0.3s ease 0s; bottom: 14px; right: -186px; box-shadow: gray 0px 0px 5px; border-radius: 2px; overflow: hidden;">
+        <div class="grecaptcha-logo">
+            <iframe title="reCAPTCHA"
+                    src="https://www.google.com/recaptcha/enterprise/anchor?ar=1&amp;k=6LfCVLAUAAAAALFwwRnnCJ12DalriUGbj8FW_J39&amp;co=aHR0cHM6Ly9vcGVuLnNwb3RpZnkuY29tOjQ0Mw..&amp;hl=en&amp;v=UrRmT3mBwY326qQxUfVlHu1P&amp;size=invisible&amp;cb=x5sxus63rtwd"
+                    width="256" height="60" role="presentation" name="a-ltd1xs4u06b1" frameborder="0" scrolling="no"
+                    sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation allow-modals allow-popups-to-escape-sandbox"></iframe>
+        </div>
+        <div class="grecaptcha-error"></div>
+        <textarea id="g-recaptcha-response-100000" name="g-recaptcha-response" class="g-recaptcha-response"
+                  style="width: 250px; height: 40px; border: 1px solid rgb(193, 193, 193); margin: 10px 25px; padding: 0px; resize: none; display: none;"></textarea>
+    </div>
+    <iframe style="display: none;"></iframe>
+</div>
+<div id="ad-tracking-pixel" style="display: none;"></div>
+<script async="" src="//www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
+<div id="main">
+    <div data-testid="root" class="Root encore-dark-theme">
+        <div></div>
+        <div class="Root__top-container">
+            <div class="Root__top-bar">
+                <header aria-label="Top bar and user menu" class="Hs_M1kkmTOjAAOogsztS">
+                    <div class="Hn_m1H5t0xMhZa46UHuC" style="background-color: rgb(143, 107, 80); opacity: 1;">
+                        <div class="jNSwrrV1feJDbTAzoSUb"></div>
+                    </div>
+                    <div class="AbprnDVcaZJaQn627rXZ">
+                        <button data-testid="top-bar-back-button" aria-hidden="true" aria-label="Go back"
+                                class="dc83urBingOKo8_8TbL2 _BeT9uB8LDqb2_yQWxJj" aria-expanded="false">
+                            <svg role="img" focusable="false" height="24" width="24" viewBox="0 0 24 24"
+                                 class="Svg-ytk21e-0 bevrDs aHN1vHt_AzvQXKPGAGn6">
+                                <polyline points="16 4 7 12 16 20" fill="none" stroke="#181818"></polyline>
+                            </svg>
+                        </button>
+                        <button data-testid="top-bar-forward-button" aria-hidden="true" aria-label="Go forward"
+                                class="dc83urBingOKo8_8TbL2 __FVoYOgC04GQV8Bp3kO" aria-expanded="false">
+                            <svg role="img" focusable="false" height="24" width="24" viewBox="0 0 24 24"
+                                 class="Svg-ytk21e-0 bevrDs aHN1vHt_AzvQXKPGAGn6">
+                                <polyline points="8 4 17 12 8 20" fill="none" stroke="#181818"></polyline>
+                            </svg>
+                        </button>
+                    </div>
+                    <div data-testid="topbar-content-wrapper" class="W_KeHKVV8OrdOIra3rHO">
+                        <div data-testid="topbar-content"
+                             class="ZNUmRRzAWeOlAnaaytKp _NHkrI_5D1Oh2YDs2N8X OCJIFM2EQ5YlJEY6nMBU">
+                            <div class="DgqN4Oc7YFckYCsta4p_"><span class="ALUFFFCL3HvPuFSOSfeu" draggable="false">STARSET with VOLA</span><a
+                                    draggable="false" class="NfNDI9efLay2gjAN9un9" target="_blank"
+                                    href="https://www.songkick.com/concerts/39905828-starset-at-rockhal-club?utm_source=8123&amp;utm_medium=partner&amp;utm_content=831ef4acdc69201b91609c5aa49755f7&amp;utm_campaign=entity"
+                                    rel="noopener nofollow">
+                                <button class="MgL79SorehxR01FG_x8G t5cpZkLic_tfF1qAxBiu h80QqqFiqP_GK15dvpo0"
+                                        type="button">Find Tickets
+                                </button>
+                            </a></div>
+                        </div>
+                    </div>
+                    <button class="gnrRbt9B6OGpcu8Bz0PU" type="button" data-testid="user-widget-link"
+                            aria-expanded="false">
+                        <figure class="CyJ77qBULrbbmSU_fRV1" title="asger" data-testid="user-widget-avatar"
+                                style="width: 28px; height: 28px;">
+                            <div class="" style="width: 28px; height: 28px; inset-inline-start: 0px;"><img
+                                    aria-hidden="false" draggable="false" loading="eager"
+                                    src="https://i.scdn.co/image/ab6775700000ee8546fb0470fbbda81f27fbefd2" alt="asger"
+                                    class="lZHD9qKHJOlxxGijUBTE n_AY8EW_6dXr_zP97FQn"></div>
+                        </figure>
+                        <span class="mTCbxCRZ3ix45gYvxckB TQQSam9tGsRXGj4aGFSc" dir="auto" as="span"
+                              data-testid="user-widget-name">asger</span>
+                        <svg role="img" height="16" width="16" class="Svg-sc-1bi12j5-0 gSLhUO zlXkx48bPJsjDXoqsZvD"
+                             viewBox="0 0 16 16">
+                            <path d="M3 6l5 5.794L13 6z"></path>
+                        </svg>
+                    </button>
+                </header>
+                <div></div>
+            </div>
+            <nav aria-label="Main" class="Root__nav-bar">
+                <div class="Nm2fPQjOSg0clIF_htNY">
+                    <div class="WwvPOGZNZ1wgULKgPYUw" role="banner"><a aria-current="page"
+                                                                       class="logo mV4rkvrwE573uIg5eRqd active"
+                                                                       draggable="false" href="/">
+                        <svg viewBox="0 0 1134 340" class="spotify-logo--text"><title>Spotify</title>
+                            <path fill="currentColor"
+                                  d="M8 171c0 92 76 168 168 168s168-76 168-168S268 4 176 4 8 79 8 171zm230 78c-39-24-89-30-147-17-14 2-16-18-4-20 64-15 118-8 162 19 11 7 0 24-11 18zm17-45c-45-28-114-36-167-20-17 5-23-21-7-25 61-18 136-9 188 23 14 9 0 31-14 22zM80 133c-17 6-28-23-9-30 59-18 159-15 221 22 17 9 1 37-17 27-54-32-144-35-195-19zm379 91c-17 0-33-6-47-20-1 0-1 1-1 1l-16 19c-1 1-1 2 0 3 18 16 40 24 64 24 34 0 55-19 55-47 0-24-15-37-50-46-29-7-34-12-34-22s10-16 23-16 25 5 39 15c0 0 1 1 2 1s1-1 1-1l14-20c1-1 1-1 0-2-16-13-35-20-56-20-31 0-53 19-53 46 0 29 20 38 52 46 28 6 32 12 32 22 0 11-10 17-25 17zm95-77v-13c0-1-1-2-2-2h-26c-1 0-2 1-2 2v147c0 1 1 2 2 2h26c1 0 2-1 2-2v-46c10 11 21 16 36 16 27 0 54-21 54-61s-27-60-54-60c-15 0-26 5-36 17zm30 78c-18 0-31-15-31-35s13-34 31-34 30 14 30 34-12 35-30 35zm68-34c0 34 27 60 62 60s62-27 62-61-26-60-61-60-63 27-63 61zm30-1c0-20 13-34 32-34s33 15 33 35-13 34-32 34-33-15-33-35zm140-58v-29c0-1 0-2-1-2h-26c-1 0-2 1-2 2v29h-13c-1 0-2 1-2 2v22c0 1 1 2 2 2h13v58c0 23 11 35 34 35 9 0 18-2 25-6 1 0 1-1 1-2v-21c0-1 0-2-1-2h-2c-5 3-11 4-16 4-8 0-12-4-12-12v-54h30c1 0 2-1 2-2v-22c0-1-1-2-2-2h-30zm129-3c0-11 4-15 13-15 5 0 10 0 15 2h1s1-1 1-2V93c0-1 0-2-1-2-5-2-12-3-22-3-24 0-36 14-36 39v5h-13c-1 0-2 1-2 2v22c0 1 1 2 2 2h13v89c0 1 1 2 2 2h26c1 0 1-1 1-2v-89h25l37 89c-4 9-8 11-14 11-5 0-10-1-15-4h-1l-1 1-9 19c0 1 0 3 1 3 9 5 17 7 27 7 19 0 30-9 39-33l45-116v-2c0-1-1-1-2-1h-27c-1 0-1 1-1 2l-28 78-30-78c0-1-1-2-2-2h-44v-3zm-83 3c-1 0-2 1-2 2v113c0 1 1 2 2 2h26c1 0 1-1 1-2V134c0-1 0-2-1-2h-26zm-6-33c0 10 9 19 19 19s18-9 18-19-8-18-18-18-19 8-19 18zm245 69c10 0 19-8 19-18s-9-18-19-18-18 8-18 18 8 18 18 18zm0-34c9 0 17 7 17 16s-8 16-17 16-16-7-16-16 7-16 16-16zm4 18c3-1 5-3 5-6 0-4-4-6-8-6h-8v19h4v-6h4l4 6h5zm-3-9c2 0 4 1 4 3s-2 3-4 3h-4v-6h4z"></path>
+                        </svg>
+                    </a></div>
+                    <ul class="yJ3fXO0ng7FAROlJvuC5">
+                        <li class="_5fRQsy_dn_0u38wC6Sb InvalidDropTarget"><a class="link-subtle _1Aw4F3MWMNfIoWWAI44"
+                                                                              draggable="false" href="/">
+                            <svg role="img" height="24" width="24" class="Svg-sc-1bi12j5-0 gSLhUO home-icon"
+                                 viewBox="0 0 24 24">
+                                <path d="M9 14h6v7h5V7.8l-8-4.6-8 4.6V21h5v-7zm1 8H3V7.2L12 2l9 5.2V22h-7v-7h-4v7z"></path>
+                            </svg>
+                            <svg role="img" height="24" width="24" class="Svg-sc-1bi12j5-0 gSLhUO home-active-icon"
+                                 viewBox="0 0 24 24">
+                                <path d="M21 22V7.174l-9.001-5.195L3 7.214V22h7v-7h4v7z"></path>
+                            </svg>
+                            <span class="ellipsis-one-line TQQSam9tGsRXGj4aGFSc" as="span">Home</span></a></li>
+                        <li class="_5fRQsy_dn_0u38wC6Sb InvalidDropTarget"><a class="link-subtle _1Aw4F3MWMNfIoWWAI44"
+                                                                              draggable="false" href="/search">
+                            <svg role="img" height="24" width="24" class="Svg-sc-1bi12j5-0 gSLhUO search-icon"
+                                 viewBox="0 0 24 24">
+                                <path d="M16.387 16.623A8.47 8.47 0 0019 10.5a8.5 8.5 0 10-8.5 8.5 8.454 8.454 0 005.125-1.73l4.401 5.153.76-.649-4.399-5.151zM10.5 18C6.364 18 3 14.636 3 10.5S6.364 3 10.5 3 18 6.364 18 10.5 14.636 18 10.5 18z"></path>
+                            </svg>
+                            <svg role="img" height="24" width="24" class="Svg-sc-1bi12j5-0 gSLhUO search-active-icon"
+                                 viewBox="0 0 24 24">
+                                <path d="M16.736 16.262A8.457 8.457 0 0019 10.5a8.5 8.5 0 10-3.779 7.067l4.424 5.18 1.521-1.299-4.43-5.186zM10.5 17C6.916 17 4 14.084 4 10.5S6.916 4 10.5 4 17 6.916 17 10.5 14.084 17 10.5 17z"></path>
+                            </svg>
+                            <span class="ellipsis-one-line TQQSam9tGsRXGj4aGFSc" as="span">Search</span></a></li>
+                        <li class="_5fRQsy_dn_0u38wC6Sb">
+                            <div class="GlueDropTarget GlueDropTarget--tracks GlueDropTarget--albums GlueDropTarget--artists GlueDropTarget--playlists GlueDropTarget--playlists">
+                                <a class="link-subtle _1Aw4F3MWMNfIoWWAI44" draggable="false" href="/collection">
+                                    <svg role="img" height="24" width="24"
+                                         class="Svg-sc-1bi12j5-0 gSLhUO collection-icon" viewBox="0 0 24 24">
+                                        <path d="M13.66 4.097l-.913.406 7.797 17.513.914-.406L13.66 4.097zM3 22h1V4H3v18zm6 0h1V4H9v18z"></path>
+                                    </svg>
+                                    <svg role="img" height="24" width="24"
+                                         class="Svg-sc-1bi12j5-0 gSLhUO collection-active-icon" viewBox="0 0 24 24">
+                                        <path d="M14.617 3.893l-1.827.814 7.797 17.513 1.827-.813-7.797-17.514zM3 22h2V4H3v18zm5 0h2V4H8v18z"></path>
+                                    </svg>
+                                    <span class="ellipsis-one-line TQQSam9tGsRXGj4aGFSc"
+                                          as="span">Your Library</span></a></div>
+                        </li>
+                    </ul>
+                    <div class="vM_HBZN3SvOzSVabgF4l" data-testid="rootlist-container">
+                        <div class="cDe4LBD3UpQQCeFwsdkW">
+                            <div class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes">
+                                <button type="button" class="Ll8dPftFNqUukAiO0o7x" data-testid="create-playlist-button">
+                                    <div class="_dP3iJaUCamgrq_boBMo">
+                                        <div class="qQjVLTor_n_F9JTk0_5i">
+                                            <svg role="img" height="12" width="12" aria-hidden="true"
+                                                 viewBox="0 0 16 16" class="Svg-sc-1bi12j5-0 gSLhUO">
+                                                <path d="M14 7H9V2H7v5H2v2h5v5h2V9h5z"></path>
+                                                <path fill="none" d="M0 0h16v16H0z"></path>
+                                            </svg>
+                                        </div>
+                                    </div>
+                                    <span class="YcqIiFfHQ2HVmjoVET2Y standalone-ellipsis-one-line TQQSam9tGsRXGj4aGFSc"
+                                          as="span">Create Playlist</span></button>
+                            </div>
+                            <div class="GlueDropTarget GlueDropTarget--tracks"><a class="o_W2RZJ_KM1kJJP017df"
+                                                                                  draggable="false"
+                                                                                  href="/collection/tracks">
+                                <div class="p3ABq_fJMfqCD8q4QzsP">
+                                    <div class="U1Yw5UfcZ10iovn7gfK0">
+                                        <svg role="img" height="12" width="12" aria-hidden="true" viewBox="0 0 16 16"
+                                             class="Svg-sc-1bi12j5-0 gSLhUO">
+                                            <path fill="none" d="M0 0h16v16H0z"></path>
+                                            <path d="M13.797 2.727a4.057 4.057 0 00-5.488-.253.558.558 0 01-.31.112.531.531 0 01-.311-.112 4.054 4.054 0 00-5.487.253c-.77.77-1.194 1.794-1.194 2.883s.424 2.113 1.168 2.855l4.462 5.223a1.791 1.791 0 002.726 0l4.435-5.195a4.052 4.052 0 001.195-2.883 4.057 4.057 0 00-1.196-2.883z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                                <span class="standalone-ellipsis-one-line _FOv6viT9UZPfRSZhOSV TQQSam9tGsRXGj4aGFSc"
+                                      as="span">Liked Songs</span>
+                                <div class="jyCb270_flXKUsUooUSv"></div>
+                            </a></div>
+                            <div class="uHpYf1ZBMj9Ek7qAXTuf">
+                                <hr class="Ygv7yuBKKU_w3MFCvNXr">
+                                <div class="kYBlAcRblnjQ6kKW4JCy"></div>
+                            </div>
+                            <div class="os-host os-host-foreign os-theme-spotify os-host-overflow os-host-overflow-y os-host-resize-disabled os-host-scrollbar-horizontal-hidden Jhg9arARQVqoij0ZNu_d os-host-transition">
+                                <div class="os-resize-observer-host observed">
+                                    <div class="os-resize-observer" style="left: 0px; right: auto;"></div>
+                                </div>
+                                <div class="os-size-auto-observer observed"
+                                     style="height: calc(100% + 1px); float: left;">
+                                    <div class="os-resize-observer"></div>
+                                </div>
+                                <div class="os-content-glue"
+                                     style="margin: -8px 0px; width: 240px; height: 507px;"></div>
+                                <div class="os-padding">
+                                    <div class="os-viewport os-viewport-native-scrollbars-invisible"
+                                         style="overflow-y: scroll;">
+                                        <div class="os-content" style="padding: 8px 0px; height: 100%; width: 100%;">
+                                            <ul tabindex="0" data-testid="rootlist">
+                                                <div class="iDlSBR5JgCntHwvGPaQk" style="height: 1024px;">
+                                                    <div data-testid="top-sentinel" class="Z_dt4_lb43xDgDSsyDo8"
+                                                         style="height: 160px;">
+                                                        <div style="height: calc(100% - 160px);"></div>
+                                                        <div style="height: 160px;"></div>
+                                                    </div>
+                                                    <div style="transform: translateY(0px);">
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/1sZNJF7bkmPtSOCTb7dPDo"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">DAKKER</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/5yiKdMGh602pUxNHUb3Nas"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Spotirec-21-10-2021</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/1yU9oIn3nssZLI6nIH4W16"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Bees knees</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/2puIzwRuYceMpEYPWpY1Ya"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">EDM</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/37i9dQZF1DX29LQDcJ6Xy7"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Industrial Metal</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/5PLIAPleAea8PYocQWSpgs"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">\m/</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/3DUyXPQ21AAr8q0rZ3l7dE"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Pop</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/1vc9TSGjhToCibMAA6WAES"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Lady</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/5Ec9AgpZYDEmmmwNMmsIlX"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Og jacobsen ved alt</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/37i9dQZF1EQpj7X7UK8OOF"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Rock Mix</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/5EMaQnC5C2Bd65rEnhAjuh"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Punk meets Pop</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/58TGMboetHKf4vEGl7rJkd"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Metal</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/37i9dQZF1EM802DKxQcNf2"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Your Top Songs 2020</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/0v8eyGAnZr6MMnKH70UnsM"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">eighties bangers</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/6vDGVr652ztNWKZuHvsFvx"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Deep House 2021</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/4gwFkaeuUWtXocRpGRIHiI"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Jamie Berry - Out of My Mind [Electro Swing]</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/7t24VNZJm4Edka3JOpnBek"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Ballader!</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/3ldmE73g1R6j7IQ0vpj875"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Amaranthe &amp; Beyond The Black</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/1C3nbpcFAWbdFI8EnYMgZY"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Good christmas songs</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/6BuFC2IATGdslqUYGgHmFI"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">COPENHELL 2022 OFFICIAL PLAYLIST</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/37i9dQZF1DWXDeqyKSbZXz"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Rock klassikere</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/4FY3kHjuGy85AGFKDZlcLY"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span"
+                                                                    dir="auto">All and Only Infected Mushroom</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/37i9dQZF1Ets6YfPMI6XZ9"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Your Top Songs 2019</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/2Ligr5MdYjkoLqh7m2pApJ"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">infected</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/37i9dQZF1DX4npDJDFDYLg"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">This Is Alan Walker</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/0h6IPVFjUpSPntcuyp8Ir4"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Liked from Radio</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/1n6FSDsJBEWcgYUb4DNe9O"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">Allahu Playbomb</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/2APIaOVBWHLW9IIX0JMWHC"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">GreedIsGood 10000</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/37i9dQZF1DX3m3SSfMuzNA"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">This Is Slipknot</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/37i9dQZF1DX99A2f2lNH9g"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span" dir="auto">This is Sabaton</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                        <li class="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders">
+                                                            <div class="veu1BUqeOKBg94mEMhsQ" draggable="true"
+                                                                 data-testid="rootlist-item" style="--indentation:0;"><a
+                                                                    class="standalone-ellipsis-one-line zH7pZvuLbeGRZSnLxlRj"
+                                                                    draggable="false" tabindex="-1"
+                                                                    href="/playlist/0RTnzyVkRHuB9gAl5bYNnE"><span
+                                                                    class="C6Q_uSufk1zE4WuU3i5P _kd5kutoy5xRha0qD0Vz"
+                                                                    as="span"
+                                                                    dir="auto">Sort Søndags 66 Essentials</span></a>
+                                                                <div class="jyCb270_flXKUsUooUSv"></div>
+                                                            </div>
+                                                        </li>
+                                                    </div>
+                                                    <div data-testid="bottom-sentinel" class="_rNvMz64ZlYOJlg_vYLy"
+                                                         style="height: 192px;">
+                                                        <div style="height: 160px;"></div>
+                                                        <div style="height: calc(100% - 160px);"></div>
+                                                    </div>
+                                                </div>
+                                            </ul>
+                                            <div class="pV_gOJHfKOzu3p5Bl3ra"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="os-scrollbar os-scrollbar-horizontal os-scrollbar-unusable">
+                                    <div class="os-scrollbar-track">
+                                        <div class="os-scrollbar-handle"
+                                             style="width: 100%; transform: translate(0px, 0px);"></div>
+                                    </div>
+                                </div>
+                                <div class="os-scrollbar os-scrollbar-vertical">
+                                    <div class="os-scrollbar-track">
+                                        <div class="os-scrollbar-handle"
+                                             style="height: 49.2248%; transform: translate(0px, 0px);"></div>
+                                    </div>
+                                </div>
+                                <div class="os-scrollbar-corner"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="_ZB2JcJdiG6rpEgCd3sR">
+                        <div class="_5fRQsy_dn_0u38wC6Sb bBxxnUCgRcYCaPw1sLYI"><a
+                                class="link-subtle _1Aw4F3MWMNfIoWWAI44" draggable="false" href="/download">
+                            <svg role="img" height="24" width="24" viewBox="0 0 24 24" class="Svg-sc-1bi12j5-0 gSLhUO">
+                                <path d="M11.5 0C5.149 0 0 5.148 0 11.5 0 17.851 5.149 23 11.5 23S23 17.851 23 11.5C23 5.148 17.851 0 11.5 0zm0 22C5.71 22 1 17.29 1 11.5S5.71 1 11.5 1 22 5.71 22 11.5 17.29 22 11.5 22zm.499-6.842V5h-1v10.149l-3.418-3.975-.758.652 4.678 5.44 4.694-5.439-.757-.653-3.439 3.984z"></path>
+                            </svg>
+                            <span class="ellipsis-one-line TQQSam9tGsRXGj4aGFSc" as="span">Install App</span></a></div>
+                    </div>
+                </div>
+                <div data-testid="LayoutResizer__resize-bar" class="LayoutResizer__resize-bar LayoutResizer__inline-end"
+                     style="z-index: 1;"><label class="hidden-visually">Resize main navigation<input
+                        class="LayoutResizer__input" type="range" min="120" max="384" step="10" value="232"></label>
+                </div>
+            </nav>
+            <div class="Root__now-playing-bar">
+                <footer class="O6evDj2xd8mSlS2qiPiG" data-testid="now-playing-bar" data-testadtype="ad-type-none">
+                    <div class="_O0uCBR2Y8Du91ewelbZ">
+                        <div class="Box1MDfgY38IwF55XGKk">
+                            <div data-testid="now-playing-widget" class="rbAHEslAiUx5qCLEuFBC" role="contentinfo"
+                                 aria-label="Now playing: Sueño De Amor by Franz Liszt">
+                                <div data-testid="CoverSlotCollapsed__container" class="cHF99Lcuuw_ZBKoiA5s7"
+                                     aria-hidden="false">
+                                    <div draggable="true"><a data-testid="context-link"
+                                                             aria-label="Now playing: Sueño De Amor by Franz Liszt"
+                                                             href="/station/playlist/1yU9oIn3nssZLI6nIH4W16?uid=6CsKnwlpLtTM7g4xtwvcqG1635454769993&amp;uri=spotify%3Atrack%3A6CsKnwlpLtTM7g4xtwvcqG"
+                                                             style="border: none;">
+                                        <div class="rTRoddzgPhtf4_aobvQr">
+                                            <div class="cover-art shadow" aria-hidden="true"
+                                                 style="width: 56px; height: 56px;">
+                                                <div>
+                                                    <div class="icon">
+                                                        <svg width="80" height="81" viewBox="0 0 80 81"
+                                                             xmlns="http://www.w3.org/2000/svg"><title>Playlist
+                                                            Icon</title>
+                                                            <path d="M25.6 11.565v45.38c-2.643-3.27-6.68-5.37-11.2-5.37-7.94 0-14.4 6.46-14.4 14.4s6.46 14.4 14.4 14.4 14.4-6.46 14.4-14.4v-51.82l48-10.205V47.2c-2.642-3.27-6.678-5.37-11.2-5.37-7.94 0-14.4 6.46-14.4 14.4s6.46 14.4 14.4 14.4S80 64.17 80 56.23V0L25.6 11.565zm-11.2 65.61c-6.176 0-11.2-5.025-11.2-11.2 0-6.177 5.024-11.2 11.2-11.2 6.176 0 11.2 5.023 11.2 11.2 0 6.174-5.026 11.2-11.2 11.2zm51.2-9.745c-6.176 0-11.2-5.024-11.2-11.2 0-6.174 5.024-11.2 11.2-11.2 6.176 0 11.2 5.026 11.2 11.2 0 6.178-5.026 11.2-11.2 11.2z"
+                                                                  fill="currentColor" fill-rule="evenodd"></path>
+                                                        </svg>
+                                                    </div>
+                                                    <img aria-hidden="false" draggable="false" loading="eager"
+                                                         src="https://i.scdn.co/image/ab67616d00004851db5e2e36292dc2433478bcd2"
+                                                         data-testid="cover-art-image" alt=""
+                                                         class="lZHD9qKHJOlxxGijUBTE cover-art-image"></div>
+                                            </div>
+                                        </div>
+                                    </a></div>
+                                    <button class="Z5Ia1X7ic3ztV79sNEJ3" aria-label="Expand">
+                                        <svg height="24" role="img" width="24" viewBox="0 0 24 24"
+                                             class="SC0doQSQg4X26Ldu80j5">
+                                            <polygon
+                                                    points="15.54,21.151 5.095,12.229 15.54,3.309 16.19,4.069 6.635,12.229 16.19,20.39 "></polygon>
+                                        </svg>
+                                    </button>
+                                </div>
+                                <div class="wswgESFLnFJSNj5yZ92B">
+                                    <div class="Oah67IoA8RMGyto7eiHD">
+                                        <div class="_mSbAWxlXgc2ONtpnuXQ">
+                                            <div class="DsnEeF5Dk0ByLOeqnjEm">
+                                                <div class="K_5FuyCqhLJlBKQjHUVt" style="--trans-x:0px;">
+                                                    <div class="Oah67IoA8RMGyto7eiHD FS85JWWz3ayMxrFzBjRD"
+                                                         data-testid="context-item-info-title" as="div" dir="auto"><span
+                                                            draggable="true"><a data-testid="context-item-link"
+                                                                                href="/album/7KQwFbBMv1psDyljm5NW34"
+                                                                                style="border: none;">Sueño De Amor</a></span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="oJ1Cr4r63zeccG22G4j_"></div>
+                                    <div class="WhCzy48YjGoF1PwwQFrk">
+                                        <div class="_mSbAWxlXgc2ONtpnuXQ">
+                                            <div class="DsnEeF5Dk0ByLOeqnjEm">
+                                                <div class="K_5FuyCqhLJlBKQjHUVt" style="--trans-x:0px;">
+                                                    <div class="WhCzy48YjGoF1PwwQFrk __f_KvmuMkY3V5Ccrj44"
+                                                         data-testid="context-item-info-subtitles" as="div"
+                                                         style="color: rgb(179, 179, 179);"><span><span
+                                                            draggable="true"><a draggable="false"
+                                                                                data-testid="context-item-info-artist"
+                                                                                dir="auto"
+                                                                                href="/artist/1385hLNbrnbCJGokfH2ac2">Franz Liszt</a></span></span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <button type="button" role="switch" aria-checked="false"
+                                        aria-label="Save to Your Library"
+                                        class="Abjch8ZuaahhQPisoyO3 control-button control-button-heart"
+                                        data-testid="add-button">
+                                    <svg role="img" height="16" width="16" viewBox="0 0 16 16"
+                                         class="Svg-sc-1bi12j5-0 gSLhUO">
+                                        <path d="M13.764 2.727a4.057 4.057 0 00-5.488-.253.558.558 0 01-.31.112.531.531 0 01-.311-.112 4.054 4.054 0 00-5.487.253A4.05 4.05 0 00.974 5.61c0 1.089.424 2.113 1.168 2.855l4.462 5.223a1.791 1.791 0 002.726 0l4.435-5.195A4.052 4.052 0 0014.96 5.61a4.057 4.057 0 00-1.196-2.883zm-.722 5.098L8.58 13.048c-.307.36-.921.36-1.228 0L2.864 7.797a3.072 3.072 0 01-.905-2.187c0-.826.321-1.603.905-2.187a3.091 3.091 0 012.191-.913 3.05 3.05 0 011.957.709c.041.036.408.351.954.351.531 0 .906-.31.94-.34a3.075 3.075 0 014.161.192 3.1 3.1 0 01-.025 4.403z"></path>
+                                    </svg>
+                                </button>
+                                <div class="control-button-wrapper">
+                                    <button class="Button-sc-1dqy6lx-0 rcWVY" data-testid="control-button-undefined"
+                                            aria-label="Remove"><span aria-hidden="true"
+                                                                      class="IconWrapper__Wrapper-sc-16usrgb-0 eFbhGd"><svg
+                                            role="img" height="16" width="16" viewBox="0 0 16 16"
+                                            class="Svg-sc-1bi12j5-0 gSLhUO"><path
+                                            d="M13.323 3.454A6.985 6.985 0 007.997 1a7 7 0 104.549 12.323 7 7 0 00.777-9.869zM8.003 14a5.996 5.996 0 01-4.566-2.104 5.958 5.958 0 01-1.419-4.367 5.961 5.961 0 011.72-3.749l7.748 9.073A5.972 5.972 0 018.003 14zm4.258-1.781L4.513 3.147A5.978 5.978 0 017.997 2c1.76 0 3.424.767 4.565 2.103a5.96 5.96 0 011.419 4.367 5.946 5.946 0 01-1.72 3.749z"></path></svg></span>
+                                    </button>
+                                </div>
+                                <div>
+                                    <button data-testid="pip-toggle-button" class="neIxivoV5yzIo_yYZqET control-button">
+                                        <div class="icon">
+                                            <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
+                                                <g fill="currentColor" fill-rule="evenodd">
+                                                    <path d="M1 3v9h14V3H1zm0-1h14a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z"
+                                                          fill-rule="nonzero"></path>
+                                                    <path d="M10 8h4v3h-4z"></path>
+                                                </g>
+                                            </svg>
+                                        </div>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="_llbhPktwOwoPo2fNFbA">
+                            <div class="player-controls" data-testid="player-controls" dir="ltr"
+                                 aria-label="Player controls">
+                                <div class="player-controls__buttons">
+                                    <div class="player-controls__left">
+                                        <button class="texVXEH7twFXjUJu9Llu" disabled="" role="switch"
+                                                aria-checked="false" aria-label="Enable shuffle"
+                                                data-testid="control-button-shuffle" style="--button-size:32px;">
+                                            <svg role="img" height="16" width="16" viewBox="0 0 16 16"
+                                                 class="Svg-sc-1bi12j5-0 gSLhUO">
+                                                <path d="M4.5 6.8l.7-.8C4.1 4.7 2.5 4 .9 4v1c1.3 0 2.6.6 3.5 1.6l.1.2zm7.5 4.7c-1.2 0-2.3-.5-3.2-1.3l-.6.8c1 1 2.4 1.5 3.8 1.5V14l3.5-2-3.5-2v1.5zm0-6V7l3.5-2L12 3v1.5c-1.6 0-3.2.7-4.2 2l-3.4 3.9c-.9 1-2.2 1.6-3.5 1.6v1c1.6 0 3.2-.7 4.2-2l3.4-3.9c.9-1 2.2-1.6 3.5-1.6z"></path>
+                                            </svg>
+                                        </button>
+                                        <button class="L4O7J5ORFBAJ8bEMYXCi" aria-label="Previous"
+                                                style="--button-size:32px;">
+                                            <svg role="img" height="16" width="16" viewBox="0 0 16 16"
+                                                 class="Svg-sc-1bi12j5-0 gSLhUO">
+                                                <path d="M13 2.5L5 7.119V3H3v10h2V8.881l8 4.619z"></path>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                    <button class="_mdSS50sTvYB40RuPTE7" aria-label="Play"
+                                            data-testid="control-button-playpause" style="--button-size:32px;">
+                                        <svg role="img" height="16" width="16" viewBox="0 0 16 16"
+                                             class="Svg-sc-1bi12j5-0 gSLhUO">
+                                            <path d="M4.018 14L14.41 8 4.018 2z"></path>
+                                        </svg>
+                                    </button>
+                                    <div class="player-controls__right">
+                                        <button class="nCpaRcGYhTBxygEV_tLd" aria-label="Next"
+                                                data-testid="control-button-skip-forward" style="--button-size:32px;">
+                                            <svg role="img" height="16" width="16" viewBox="0 0 16 16"
+                                                 class="Svg-sc-1bi12j5-0 gSLhUO">
+                                                <path d="M11 3v4.119L3 2.5v11l8-4.619V13h2V3z"></path>
+                                            </svg>
+                                        </button>
+                                        <button class="enINDdBnsAC2KVIJckWK" disabled="" role="checkbox"
+                                                aria-checked="false" aria-label="Disable repeat"
+                                                data-testid="control-button-repeat" style="--button-size:32px;">
+                                            <svg role="img" height="16" width="16" viewBox="0 0 16 16"
+                                                 class="Svg-sc-1bi12j5-0 gSLhUO">
+                                                <path d="M5.5 5H10v1.5l3.5-2-3.5-2V4H5.5C3 4 1 6 1 8.5c0 .6.1 1.2.4 1.8l.9-.5C2.1 9.4 2 9 2 8.5 2 6.6 3.6 5 5.5 5zm9.1 1.7l-.9.5c.2.4.3.8.3 1.3 0 1.9-1.6 3.5-3.5 3.5H6v-1.5l-3.5 2 3.5 2V13h4.5C13 13 15 11 15 8.5c0-.6-.1-1.2-.4-1.8z"></path>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="playback-bar">
+                                    <div class="playback-bar__progress-time-elapsed __f_KvmuMkY3V5Ccrj44"
+                                         data-testid="playback-position" as="div" style="color: rgb(179, 179, 179);">
+                                        2:53
+                                    </div>
+                                    <div class="ceBzGJlZf0btrwpCelcK ftIPzHUUP26CZSFpj90b"
+                                         data-testid="playback-progressbar"><label class="hidden-visually">Change
+                                        progress<input type="range" min="0" max="199" step="5"
+                                                       aria-valuetext="2:53/3:19" value="173"></label>
+                                        <div class="nUQLDnMZ4D_pTkaeowQD" data-testid="progress-bar"
+                                             style="--progress-bar-transform:86.9347%;">
+                                            <div class="WaLaIilXoL4rASG8a8KN" data-testid="progress-bar-background">
+                                                <div class="yaVzc4bseRnztmfRv_u3">
+                                                    <div class="dt2nNuPMSEfD8Pv4Na9G"></div>
+                                                </div>
+                                                <div class="r1WWMKiO1G1JXTGc5ASd"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="z7ggpzN06UkYg7bLwVqT __f_KvmuMkY3V5Ccrj44" as="div"
+                                         data-testid="playback-duration" data-test-position="173367"
+                                         style="color: rgb(179, 179, 179);">3:19
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="cbXpo0LWCGi0cFQLgjl5">
+                            <div class="ExtraControls">
+                                <div class="GlueDropTarget GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes">
+                                    <div class="control-button-wrapper">
+                                        <button class="Button-sc-1dqy6lx-0 rcWVY" data-testid="control-button-undefined"
+                                                aria-label="Queue"><span aria-hidden="true"
+                                                                         class="IconWrapper__Wrapper-sc-16usrgb-0 eFbhGd"><svg
+                                                role="img" height="16" width="16" viewBox="0 0 16 16"
+                                                class="Svg-sc-1bi12j5-0 gSLhUO"><path
+                                                d="M2 2v5l4.33-2.5L2 2zm0 12h14v-1H2v1zm0-4h14V9H2v1zm7-5v1h7V5H9z"></path></svg></span>
+                                        </button>
+                                    </div>
+                                </div>
+                                <div><span class="_YTIh_07iuvSGuaUVwCa"><button
+                                        class="control-button mLdH47LCdymzD0aCRrRw"><svg role="img" height="16"
+                                                                                         width="16"
+                                                                                         aria-label="Connect to a device"
+                                                                                         viewBox="0 0 16 16"
+                                                                                         class="Svg-sc-1bi12j5-0 gSLhUO"><path
+                                        d="M0 3v8c0 .55.45 1 1 1h5v-1H1V3h5V2H1c-.55 0-1 .45-1 1zm3 11.5c0 .275.225.5.5.5H6v-1H3.5c-.275 0-.5.225-.5.5zM15 2H9c-.55 0-1 .45-1 1v11c0 .55.45 1 1 1h6c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm0 12H9V3h6v11zm-3-8a.75.75 0 100-1.5.75.75 0 000 1.5zm0 6a2 2 0 100-4 2 2 0 000 4zm0-3c.551 0 1 .449 1 1s-.449 1-1 1-1-.449-1-1 .449-1 1-1z"></path></svg></button></span>
+                                </div>
+                                <div class="volume-bar" data-testid="volume-bar" dir="ltr">
+                                    <button class="volume-bar__icon-button control-button" aria-label="Mute"
+                                            aria-describedby="volume-icon">
+                                        <svg role="presentation" height="16" width="16" aria-label="Volume high"
+                                             id="volume-icon" viewBox="0 0 16 16" class="Svg-sc-1bi12j5-0 gSLhUO">
+                                            <path d="M12.945 1.379l-.652.763c1.577 1.462 2.57 3.544 2.57 5.858s-.994 4.396-2.57 5.858l.651.763a8.966 8.966 0 00.001-13.242zm-2.272 2.66l-.651.763a4.484 4.484 0 01-.001 6.397l.651.763c1.04-1 1.691-2.404 1.691-3.961s-.65-2.962-1.69-3.962zM0 5v6h2.804L8 14V2L2.804 5H0zm7-1.268v8.536L3.072 10H1V6h2.072L7 3.732z"></path>
+                                        </svg>
+                                    </button>
+                                    <div class="ceBzGJlZf0btrwpCelcK ftIPzHUUP26CZSFpj90b"><label
+                                            class="hidden-visually">Change volume<input type="range" min="0" max="1"
+                                                                                        step="0.1" value="1"></label>
+                                        <div class="nUQLDnMZ4D_pTkaeowQD" data-testid="progress-bar"
+                                             style="--progress-bar-transform:100%;">
+                                            <div class="WaLaIilXoL4rASG8a8KN" data-testid="progress-bar-background">
+                                                <div class="yaVzc4bseRnztmfRv_u3">
+                                                    <div class="dt2nNuPMSEfD8Pv4Na9G"></div>
+                                                </div>
+                                                <div class="r1WWMKiO1G1JXTGc5ASd"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <button class="control-button" aria-label="Full screen" title="Full screen"
+                                        data-testid="fullscreen-mode-button">
+                                    <svg role="img" height="16" width="16" viewBox="0 0 16 16"
+                                         class="Svg-sc-1bi12j5-0 gSLhUO">
+                                        <path d="M6.064 10.229l-2.418 2.418L2 11v4h4l-1.647-1.646 2.418-2.418-.707-.707zM11 2l1.647 1.647-2.418 2.418.707.707 2.418-2.418L15 6V2h-4z"></path>
+                                    </svg>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </footer>
+            </div>
+            <div class="Root__main-view">
+                <main class="main-view-container" tabindex="-1" aria-label="STARSET">
+                    <div class="under-main-view">
+                        <div style="--scroll:0.313793;">
+                            <div data-testid="background-image" class="YboT9C61kapUCdQnsEmR _RsE6aTVwN0z0t6B_3Y4"
+                                 style="background-image: url(&quot;https://i.scdn.co/image/ab6761860000101684c50f41154e0f8bf1e0c7a8&quot;);"></div>
+                            <div class="YboT9C61kapUCdQnsEmR _2UQIjShn4okBf3lckuD" style="--bgColor:#8F6B50;"></div>
+                        </div>
+                    </div>
+                    <div class="os-host os-host-foreign os-theme-spotify os-host-resize-disabled os-host-scrollbar-horizontal-hidden main-view-container__scroll-node os-host-transition os-host-overflow os-host-overflow-y">
+                        <div class="os-resize-observer-host observed">
+                            <div class="os-resize-observer" style="left: 0px; right: auto;"></div>
+                        </div>
+                        <div class="os-padding">
+                            <div class="os-viewport os-viewport-native-scrollbars-invisible"
+                                 style="overflow-y: scroll;">
+                                <div class="os-content" style="padding: 0px; height: 100%; width: 100%;">
+                                    <div class="main-view-container__scroll-node-child-spacer"></div>
+                                    <div class="main-view-container__scroll-node-child"
+                                         style="min-height: calc(((100vh - 64px) - 90px) - 519px);">
+                                        <section class="Y0GeAIqWOn05Uv10nV6M">
+                                            <div class="contentSpacing KrA8ZIJfc8j44C0nxKn2 mLG9eYDONp4rb_PGysHR tccSRnkfHP5_6JxiVb_U">
+                                                <div class="Bkm7hB2AjwzHExha8C91"><span class="hpEaYMtPFnKqeonqK9WY"><div
+                                                        class="aHsZc_I_MTzppipLS9Us"><h3
+                                                        class="_NOjwV3xzBXHMqtfDc_1 QfLKaGH1i_Z5VejejiYa"
+                                                        as="h3">FEB 15</h3></div></span><span dir="auto"
+                                                                                              class="U_AdmCe4oCcTEvsjqLFw"
+                                                                                              draggable="false"><h1
+                                                        class="_meqsRRoQONlQfjhfxzp" as="h1" dir="auto"
+                                                        style="padding: 0.08em 0px; visibility: visible; width: 100%; font-size: 72px; line-height: 72px;">STARSET with VOLA</h1></span>
+                                                </div>
+                                                <div></div>
+                                            </div>
+                                            <div class="tI_6KcTGd3F5KJxhdlWF">
+                                                <div class="_XX7ZgHsEhiQ3gO0kz5Q"
+                                                     style="background-color: rgb(143, 107, 80);"></div>
+                                                <div class="KaHgjeEKL0cAFQdzwYgU">
+                                                    <div class="FfQ1kPi3boVEOx_B4Zbp">
+                                                        <h3 class="QfLKaGH1i_Z5VejejiYa" as="h3"><a draggable="false"
+                                                                                                    target="_blank"
+                                                                                                    href="https://maps.google.com/?q=Rockhal%20Club%2CEsch%20Sur%20Alzette&amp;ll=49.49984,5.94763"
+                                                                                                    rel="noopener nofollow">
+                                                            <h3 class="QfLKaGH1i_Z5VejejiYa" as="h3">Rockhal Club, Esch
+                                                                Sur Alzette</h3></a></h3>
+                                                        <h3 class="OL94Px7vy5AZW5O_3Nhs FS85JWWz3ayMxrFzBjRD" as="h3">
+                                                            Tue, Feb 15 • 8:00 PM</h3>
+                                                        <h3 class="T7MMS7BYKYPAPGlT_UKg FS85JWWz3ayMxrFzBjRD" as="h3">
+                                                            Available on Songkick</h3>
+                                                        <div class="ZjoG5fIY5MMfqHGtKCXh"><a draggable="false"
+                                                                                             class="NfNDI9efLay2gjAN9un9"
+                                                                                             target="_blank"
+                                                                                             href="https://www.songkick.com/concerts/39905828-starset-at-rockhal-club?utm_source=8123&amp;utm_medium=partner&amp;utm_content=831ef4acdc69201b91609c5aa49755f7&amp;utm_campaign=entity"
+                                                                                             rel="noopener nofollow">
+                                                            <button class="MgL79SorehxR01FG_x8G t5cpZkLic_tfF1qAxBiu"
+                                                                    type="button">Find Tickets
+                                                            </button>
+                                                        </a>
+                                                            <button type="button" aria-haspopup="menu" aria-label="More"
+                                                                    class="qiSIbTMb4HOiTFObpGVJ mjQErlXU4nDJqyqUgprZ"
+                                                                    data-testid="more-button">
+                                                                <svg role="img" height="32" width="32"
+                                                                     viewBox="0 0 32 32"
+                                                                     class="Svg-sc-1bi12j5-0 gSLhUO">
+                                                                    <path d="M5.998 13.999A2 2 0 105.999 18a2 2 0 00-.001-4zm10.001 0A2 2 0 1016 18a2 2 0 000-4zm10.001 0A2 2 0 1026.001 18 2 2 0 0026 14z"></path>
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                    <div class="TrKS3KWf9PKOTm_bZWks">
+                                                        <section class="WR_hhqOgNl2oxWjFP6Ml"
+                                                                 data-testid="component-shelf" aria-label="The lineup">
+                                                            <div class="RzpZ0LkZ0jXpxHUfv4kk">
+                                                                <div class="KjREAf4amsU7qu_xBMFI">
+                                                                    <div class="JP949CWeGDTkKxKynaZ9"><h2
+                                                                            class="QfLKaGH1i_Z5VejejiYa" as="h2"><a
+                                                                            draggable="false" data-testid="see-all-link"
+                                                                            class="jXGbtRS_8kfcqhxKQvqW"
+                                                                            href="/artist/0kD8IT1CzF7js2XKM9lLLa/discography">The
+                                                                        lineup</a></h2></div>
+                                                                    <a draggable="false"
+                                                                       class="EOh_IvQ_4mD_IO7WqPts fs1TCVDHYzHZfI_TsOkw"
+                                                                       href="/artist/0kD8IT1CzF7js2XKM9lLLa/discography"><span
+                                                                            class="_izo41qKZR2b171s8s2O" as="span">See discography</span></a>
+                                                                </div>
+                                                            </div>
+                                                            <div data-testid="grid-container"
+                                                                 class="QNIdF86JU_1vh07jXsY2 Hgy6HYholBzqtff1fOai"
+                                                                 style="--minimumColumnWidth:180px;"><a
+                                                                    draggable="false" class="xRM6JpKoKLJX5GSOtONe"
+                                                                    href="/artist/0kD8IT1CzF7js2XKM9lLLa">
+                                                                <div>
+                                                                    <div data-testid="image-container"
+                                                                         class="mOuvq_cUTcm_nPOqh14h"
+                                                                         style="background-image: linear-gradient(rgba(18, 18, 18, 0) 0%, rgba(18, 18, 18, 0.5) 50.52%, rgba(18, 18, 18, 0.7) 100%), url(&quot;https://i.scdn.co/image/ab67616100005174d1ca725c8d1062ebaa1ad069&quot;);"></div>
+                                                                </div>
+                                                                <div class="_SxC3a3YsDuQ2dP71Xer">
+                                                                    <div class="j6Z0zMYhMTAPP8GgbDIF"><h4
+                                                                            class="e__WE8Yvp6gJUeljpjho _bgua6bvZNhgL1DN1PVa t3O1_UyoAi3eYRHDP3LB"
+                                                                            as="h4">Headliner</h4></div>
+                                                                    <h2 class="fhNamieteRzoekMfM0Pd HnZ4fZrT_hc6RFSnYoJ9"
+                                                                        as="h2">STARSET</h2></div>
+                                                            </a>
+                                                                <div class="YWQ6MaodStrAvAMCg1wx">
+                                                                    <div class="tOHTUNLa5F8c3WnIjWHC" draggable="true">
+                                                                        <div class="_OKQlIff_lpuqqgnDBhg">
+                                                                            <div class="byhpDrPqhYGoCXVANcn9">
+                                                                                <div class=""><img aria-hidden="false"
+                                                                                                   draggable="false"
+                                                                                                   loading="lazy"
+                                                                                                   src="https://i.scdn.co/image/ab67616d00001e02e9cfbebbdfc182c1adc73da6"
+                                                                                                   data-testid="card-image"
+                                                                                                   alt=""
+                                                                                                   class="lZHD9qKHJOlxxGijUBTE Fy0HazWVKsw9Fg95AnSR">
+                                                                                </div>
+                                                                            </div>
+                                                                            <div class="hVUUxTzkzVSKTvPVwoUi">
+                                                                                <button class="_47lzH_9ZSVGM4UUdX90 tBo7WbUk9fgBuWpnsy0_"
+                                                                                        aria-label="Play Transmissions by STARSET"
+                                                                                        data-testid="play-button"
+                                                                                        style="--size:40px;">
+                                                                                    <svg height="16" role="img"
+                                                                                         width="16" viewBox="0 0 24 24"
+                                                                                         aria-hidden="true">
+                                                                                        <polygon
+                                                                                                points="21.57 12 5.98 3 5.98 21 21.57 12"
+                                                                                                fill="currentColor"></polygon>
+                                                                                    </svg>
+                                                                                </button>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="pBYYvPgTdyA8MQPvzAeg"><a
+                                                                                draggable="false" title="Transmissions"
+                                                                                class="_bjcti2dbGjtjcbe676J" dir="auto"
+                                                                                href="/album/1OCoLxZ0ThaNLObdcsO4yk">
+                                                                            <div class="_7l0TLYcSaw8w6epnBhj GG4lScbAogw4Q_mXWbn9"
+                                                                                 as="div">Transmissions
+                                                                            </div>
+                                                                        </a>
+                                                                            <div class="H9PRzjoipXUvDjF9wNh2 FS85JWWz3ayMxrFzBjRD"
+                                                                                 as="div"
+                                                                                 style="color: rgb(179, 179, 179);"><a
+                                                                                    draggable="false" dir="auto"
+                                                                                    href="/artist/0kD8IT1CzF7js2XKM9lLLa">STARSET</a>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="RZZivavNmxhfVAj_fs6O"
+                                                                             data-testid="card-click-handler"></div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </section>
+                                                        <section class="WR_hhqOgNl2oxWjFP6Ml"
+                                                                 data-testid="component-shelf" aria-label="">
+                                                            <div class="RzpZ0LkZ0jXpxHUfv4kk">
+                                                                <div class="KjREAf4amsU7qu_xBMFI">
+                                                                    <div class="JP949CWeGDTkKxKynaZ9"><h2
+                                                                            class="QfLKaGH1i_Z5VejejiYa" as="h2"><a
+                                                                            draggable="false" data-testid="see-all-link"
+                                                                            class="jXGbtRS_8kfcqhxKQvqW"
+                                                                            href="/artist/1HQjBwlj8FSHMhVaNQ4tEI/discography"></a>
+                                                                    </h2></div>
+                                                                    <a draggable="false"
+                                                                       class="EOh_IvQ_4mD_IO7WqPts fs1TCVDHYzHZfI_TsOkw"
+                                                                       href="/artist/1HQjBwlj8FSHMhVaNQ4tEI/discography"><span
+                                                                            class="_izo41qKZR2b171s8s2O" as="span">See discography</span></a>
+                                                                </div>
+                                                            </div>
+                                                            <div data-testid="grid-container"
+                                                                 class="QNIdF86JU_1vh07jXsY2 Hgy6HYholBzqtff1fOai"
+                                                                 style="--minimumColumnWidth:180px;"><a
+                                                                    draggable="false" class="xRM6JpKoKLJX5GSOtONe"
+                                                                    href="/artist/1HQjBwlj8FSHMhVaNQ4tEI">
+                                                                <div>
+                                                                    <div data-testid="image-container"
+                                                                         class="mOuvq_cUTcm_nPOqh14h"
+                                                                         style="background-image: linear-gradient(rgba(18, 18, 18, 0) 0%, rgba(18, 18, 18, 0.5) 50.52%, rgba(18, 18, 18, 0.7) 100%), url(&quot;https://i.scdn.co/image/ab676161000051744e64b7427f58244c89a5ea03&quot;);"></div>
+                                                                </div>
+                                                                <div class="_SxC3a3YsDuQ2dP71Xer"><h2
+                                                                        class="fhNamieteRzoekMfM0Pd HnZ4fZrT_hc6RFSnYoJ9"
+                                                                        as="h2">VOLA</h2></div>
+                                                            </a>
+                                                                <div class="YWQ6MaodStrAvAMCg1wx">
+                                                                    <div class="tOHTUNLa5F8c3WnIjWHC" draggable="true">
+                                                                        <div class="_OKQlIff_lpuqqgnDBhg">
+                                                                            <div class="byhpDrPqhYGoCXVANcn9">
+                                                                                <div class=""><img aria-hidden="false"
+                                                                                                   draggable="false"
+                                                                                                   loading="lazy"
+                                                                                                   src="https://i.scdn.co/image/ab67616d00001e028d2f70792b45fe47aa18df9c"
+                                                                                                   data-testid="card-image"
+                                                                                                   alt=""
+                                                                                                   class="lZHD9qKHJOlxxGijUBTE Fy0HazWVKsw9Fg95AnSR">
+                                                                                </div>
+                                                                            </div>
+                                                                            <div class="hVUUxTzkzVSKTvPVwoUi">
+                                                                                <button class="_47lzH_9ZSVGM4UUdX90 tBo7WbUk9fgBuWpnsy0_"
+                                                                                        aria-label="Play Applause Of A Distant Crowd by VOLA"
+                                                                                        data-testid="play-button"
+                                                                                        style="--size:40px;">
+                                                                                    <svg height="16" role="img"
+                                                                                         width="16" viewBox="0 0 24 24"
+                                                                                         aria-hidden="true">
+                                                                                        <polygon
+                                                                                                points="21.57 12 5.98 3 5.98 21 21.57 12"
+                                                                                                fill="currentColor"></polygon>
+                                                                                    </svg>
+                                                                                </button>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="pBYYvPgTdyA8MQPvzAeg"><a
+                                                                                draggable="false"
+                                                                                title="Applause Of A Distant Crowd"
+                                                                                class="_bjcti2dbGjtjcbe676J" dir="auto"
+                                                                                href="/album/2sGgHaebVkUg4PGcNp6XKA">
+                                                                            <div class="_7l0TLYcSaw8w6epnBhj GG4lScbAogw4Q_mXWbn9"
+                                                                                 as="div">Applause Of A Distant Crowd
+                                                                            </div>
+                                                                        </a>
+                                                                            <div class="H9PRzjoipXUvDjF9wNh2 FS85JWWz3ayMxrFzBjRD"
+                                                                                 as="div"
+                                                                                 style="color: rgb(179, 179, 179);"><a
+                                                                                    draggable="false" dir="auto"
+                                                                                    href="/artist/1HQjBwlj8FSHMhVaNQ4tEI">VOLA</a>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="RZZivavNmxhfVAj_fs6O"
+                                                                             data-testid="card-click-handler"></div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </section>
+                                                    </div>
+                                                    <div class="sFa8gYQv_m0h9QsdpaLA">
+                                                        <section class="WR_hhqOgNl2oxWjFP6Ml"
+                                                                 data-testid="component-shelf"
+                                                                 aria-label="More events you might like">
+                                                            <div class="RzpZ0LkZ0jXpxHUfv4kk">
+                                                                <div class="KjREAf4amsU7qu_xBMFI">
+                                                                    <div class="JP949CWeGDTkKxKynaZ9"><h2
+                                                                            class="jXGbtRS_8kfcqhxKQvqW QfLKaGH1i_Z5VejejiYa"
+                                                                            as="h2" tabindex="-1">More events you might
+                                                                        like</h2></div>
+                                                                </div>
+                                                            </div>
+                                                            <div data-testid="grid-container"
+                                                                 class="QNIdF86JU_1vh07jXsY2 Hgy6HYholBzqtff1fOai"
+                                                                 style="--minimumColumnWidth:180px;"><a
+                                                                    draggable="false" class="ukLX7MYyFZjnZKGabiVb"
+                                                                    href="/concerts">
+                                                                <div>
+                                                                    <div class="aZCx0zlqpjGttz7SsBO3"
+                                                                         style="background-image: linear-gradient(rgba(18, 18, 18, 0) 0%, rgba(18, 18, 18, 0.5) 50.52%, rgba(18, 18, 18, 0.7) 100%), url(&quot;https://concerts.spotifycdn.com/ConcertHubCard.png&quot;);"></div>
+                                                                </div>
+                                                                <div class="_6KpRV6GSPpOpDIGmazT"><h2
+                                                                        class="QfLKaGH1i_Z5VejejiYa" as="h2">Browse more
+                                                                    concerts</h2></div>
+                                                            </a><a draggable="false" class="x8W2XQVxxPzNn946iIWj"
+                                                                   href="/concert/08rbjxjm1ZKE1A1QM9wPms">
+                                                                <div>
+                                                                    <div data-testid="image-container"
+                                                                         class="aVhGS9jOQU5NV_QRfCba"
+                                                                         style="background-image: linear-gradient(rgba(18, 18, 18, 0) 0%, rgba(6, 6, 6, 0.6) 60%, rgba(0, 0, 0, 0.7) 100%), url(&quot;https://i.scdn.co/image/ab67616100005174ba0eda07c5a1246b4c724977&quot;);"></div>
+                                                                </div>
+                                                                <time class="mvsb4XgMWue3scs1x9cf"
+                                                                      datetime="2021-11-13T19:00:00+0100"><h5
+                                                                        class="Z_ETdpLYpXzQ0KL6Yo0k _izo41qKZR2b171s8s2O"
+                                                                        as="h5">NOV</h5>
+                                                                    <h1 class="_Qyg17ZQBMlfq8GCA4vd QfLKaGH1i_Z5VejejiYa"
+                                                                        as="h1">13</h1></time>
+                                                                <div class="kQBxrPOAhMhPA_MCSpRJ" dir="auto"><h2
+                                                                        class="eF_iqV6fuFzyZ8IOEka7 _izo41qKZR2b171s8s2O"
+                                                                        as="h2">Sat, 7:00 PM</h2>
+                                                                    <h2 class="si8CFykRKeQOEEz9jJnh _Q20A60s8vokf3sUp9vw t3O1_UyoAi3eYRHDP3LB"
+                                                                        as="h2">LIVLØS &amp; IOTUNN</h2>
+                                                                    <div class="_xiBdOWGZwffxdH6Sw7c"><h2
+                                                                            class="EybveBUBw_K3Mqa4O788 FS85JWWz3ayMxrFzBjRD"
+                                                                            as="h2" data-testid="location-name">Atlas,
+                                                                        Aarhus</h2></div>
+                                                                </div>
+                                                            </a><a draggable="false" class="x8W2XQVxxPzNn946iIWj"
+                                                                   href="/concert/0Y9vl2wp5usAUbvW2NULDi">
+                                                                <div>
+                                                                    <div data-testid="image-container"
+                                                                         class="aVhGS9jOQU5NV_QRfCba"
+                                                                         style="background-image: linear-gradient(rgba(18, 18, 18, 0) 0%, rgba(6, 6, 6, 0.6) 60%, rgba(0, 0, 0, 0.7) 100%), url(&quot;https://i.scdn.co/image/ab67616100005174f8ffed21369e63d30c2fa8d1&quot;);"></div>
+                                                                </div>
+                                                                <time class="mvsb4XgMWue3scs1x9cf"
+                                                                      datetime="2021-12-04T21:00:00+0100"><h5
+                                                                        class="Z_ETdpLYpXzQ0KL6Yo0k _izo41qKZR2b171s8s2O"
+                                                                        as="h5">DEC</h5>
+                                                                    <h1 class="_Qyg17ZQBMlfq8GCA4vd QfLKaGH1i_Z5VejejiYa"
+                                                                        as="h1">4</h1></time>
+                                                                <div class="kQBxrPOAhMhPA_MCSpRJ" dir="auto"><h2
+                                                                        class="eF_iqV6fuFzyZ8IOEka7 _izo41qKZR2b171s8s2O"
+                                                                        as="h2">Sat, 9:00 PM</h2>
+                                                                    <h2 class="si8CFykRKeQOEEz9jJnh _Q20A60s8vokf3sUp9vw t3O1_UyoAi3eYRHDP3LB"
+                                                                        as="h2">Bersærk</h2>
+                                                                    <div class="_xiBdOWGZwffxdH6Sw7c"><h2
+                                                                            class="EybveBUBw_K3Mqa4O788 FS85JWWz3ayMxrFzBjRD"
+                                                                            as="h2" data-testid="location-name">Train,
+                                                                        Aarhus C</h2></div>
+                                                                </div>
+                                                            </a></div>
+                                                        </section>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </section>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="os-scrollbar os-scrollbar-horizontal os-scrollbar-unusable">
+                            <div class="os-scrollbar-track">
+                                <div class="os-scrollbar-handle"
+                                     style="width: 100%; transform: translate(0px, 0px);"></div>
+                            </div>
+                        </div>
+                        <div class="os-scrollbar os-scrollbar-vertical">
+                            <div class="os-scrollbar-track">
+                                <div class="os-scrollbar-handle"
+                                     style="height: 51.4184%; transform: translate(0px, 187.965px);"></div>
+                            </div>
+                        </div>
+                        <div class="os-scrollbar-corner"></div>
+                    </div>
+                </main>
+                <div class="Root__modal-slot"></div>
+            </div>
+            <div class="h_QBzvx0yWy3wjK786NG"></div>
+        </div>
+        <div></div>
+        <div></div>
+    </div>
+</div>
+<div class="ReactModalPortal"></div>
+<div class="ReactModalPortal"></div>
+<div class="ReactModalPortal"></div>
+<div class="ReactModalPortal"></div>
+<div class="ReactModalPortal"></div>
+<div class="ReactModalPortal"></div>
+<div class="ReactModalPortal"></div>
+<div class="ReactModalPortal"></div>
+<iframe style="display: none;" name="__tcfapiLocator" title="CMP Locator"></iframe>
+<div id="onetrust-consent-sdk">
+    <div class="onetrust-pc-dark-filter ot-hide ot-fade-in"></div>
+    <div id="onetrust-pc-sdk" class="ot-sdk-container otPcCenter ot-hide ot-fade-in ot-accordions-pc" aria-modal="true"
+         role="alertdialog" lang="en" aria-label="About Your Privacy"><!-- Close Button -->
+        <button id="close-pc-btn-handler" class="main pc-close-button ot-close-icon" aria-label="Close"></button>
+        <!-- Close Button -->
+        <div id="ot-content" class="ot-main-content"><!-- Logo Tag -->
+            <div class="pc-logo-container">
+                <div class="pc-logo" role="img" aria-label="Company Logo" style="background-image: url(&quot;https://cdn.cookielaw.org/logos/static/ot_logo.png&quot;);
+                    background-position: left;"></div>
+            </div>
+            <h2 id="pc-title">About Your Privacy</h2>
+            <div id="pc-policy-text">We process your data for purposes such as delivering content or advertisements and
+                measuring the delivery of such content or advertisements to extract insights about our website. We may
+                share this information with our partners. Cookies set by Spotify are labelled “first party”; you may
+                exercise your preferences in relation to first party cookies by toggling the switch for each first party
+                cookie category below. The remaining cookies are third party cookies; you may exercise your preferences
+                in relation to each purpose by toggling the relevant switch below or by vendor by clicking “List of IAB
+                Vendors.” These choices will be signaled globally to other websites participating in the Transparency
+                and Consent Framework.
+                <br><a href="https://www.spotify.com/legal/cookies-policy/" class="privacy-notice-link" rel="noopener"
+                       target="_blank" aria-label="More information about your privacy, opens in a new tab">Cookie
+                    Policy</a></div>
+            <div id="accept-recommended-container" class="ot-sdk-row">
+                <div class="ot-sdk-column">
+                    <button id="accept-recommended-btn-handler" class="button-theme">Allow All</button>
+                </div>
+            </div>
+            <section id="cookie-preferences" class="ot-sdk-row category-group"><h3 id="manage-cookies-text"> Manage
+                Consent Preferences</h3>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="s00"><input type="checkbox"
+                                                                                                name="storage-access"
+                                                                                                id="ot-group-id-s00-toggle"
+                                                                                                aria-expanded="false"
+                                                                                                ot-accordion="true"
+                                                                                                role="button"
+                                                                                                aria-controls="ot-desc-id-s00"
+                                                                                                aria-labelledby="ot-header-id-s00">
+                    <!-- Accordion header -->
+                    <div class="accordion-header ot-always-active-group"><h4 class="category-header"
+                                                                             id="ot-header-id-s00">Strictly Necessary
+                        Cookies</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-always-active">Always Active</div>
+                        <div class="ot-switch ot-toggle ot-hide-tgl"><input type="checkbox" name="ot-group-id-s00"
+                                                                            class="switch-checkbox category-switch-handler"
+                                                                            id="ot-group-id-s00" aria-checked="true"
+                                                                            role="switch" aria-hidden="true"
+                                                                            data-optanongroupid="s00" checked=""
+                                                                            aria-labelledby="ot-header-id-s00"> <label
+                                class="ot-switch-label" for="ot-group-id-s00"><span class="ot-switch-inner"></span>
+                            <span class="ot-switch-nob"></span> <span
+                                    class="label-text">Strictly Necessary Cookies</span></label></div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><p
+                            class="ot-accordion-group-pc-container ot-category-desc" id="ot-desc-id-s00">These cookies
+                        are necessary for the service to function and cannot be switched off in our systems. They are
+                        usually only set in response to actions made by you which amount to a request for services, such
+                        as setting your privacy preferences, logging in or filling in forms. You can set your browser to
+                        block or alert you about these cookies, but some parts of the service will not then work. </p>
+                        <!-- COOKIE SUBGROUPS*** --><!-- COOKIE SUBGROUPS END*** --></div>
+                </div>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="f00"><input type="checkbox"
+                                                                                                name="storage-access"
+                                                                                                id="ot-group-id-f00-toggle"
+                                                                                                aria-expanded="false"
+                                                                                                ot-accordion="true"
+                                                                                                role="button"
+                                                                                                aria-controls="ot-desc-id-f00"
+                                                                                                aria-labelledby="ot-header-id-f00">
+                    <!-- Accordion header -->
+                    <div class="accordion-header"><h4 class="category-header" id="ot-header-id-f00">First Party
+                        Functional Cookies</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-switch ot-toggle"><input type="checkbox" name="ot-group-id-f00"
+                                                                class="switch-checkbox category-switch-handler"
+                                                                id="ot-group-id-f00" aria-checked="true" role="switch"
+                                                                data-optanongroupid="f00" checked=""
+                                                                aria-labelledby="ot-header-id-f00"> <label
+                                class="ot-switch-label" for="ot-group-id-f00"><span class="ot-switch-inner"></span>
+                            <span class="ot-switch-nob"></span> <span
+                                    class="label-text">First Party Functional Cookies</span></label></div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><p
+                            class="ot-accordion-group-pc-container ot-category-desc" id="ot-desc-id-f00">These cookies
+                        enable us to provide enhanced functionality and personalisation. If you do not allow these
+                        cookies then some or all of these services may not function properly.</p>
+                        <!-- COOKIE SUBGROUPS*** --><!-- COOKIE SUBGROUPS END*** --></div>
+                </div>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="m00"><input type="checkbox"
+                                                                                                name="storage-access"
+                                                                                                id="ot-group-id-m00-toggle"
+                                                                                                aria-expanded="false"
+                                                                                                ot-accordion="true"
+                                                                                                role="button"
+                                                                                                aria-controls="ot-desc-id-m00"
+                                                                                                aria-labelledby="ot-header-id-m00">
+                    <!-- Accordion header -->
+                    <div class="accordion-header"><h4 class="category-header" id="ot-header-id-m00">First Party
+                        Performance Cookies</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-switch ot-toggle"><input type="checkbox" name="ot-group-id-m00"
+                                                                class="switch-checkbox category-switch-handler"
+                                                                id="ot-group-id-m00" aria-checked="true" role="switch"
+                                                                data-optanongroupid="m00" checked=""
+                                                                aria-labelledby="ot-header-id-m00"> <label
+                                class="ot-switch-label" for="ot-group-id-m00"><span class="ot-switch-inner"></span>
+                            <span class="ot-switch-nob"></span> <span
+                                    class="label-text">First Party Performance Cookies</span></label></div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><p
+                            class="ot-accordion-group-pc-container ot-category-desc" id="ot-desc-id-m00">These cookies
+                        allow us to count visits and traffic sources so we can measure and improve the performance of
+                        our services. They help us to know which pages are the most and least popular and see how
+                        visitors move around the platform. If you do not allow these cookies we will not be able to
+                        monitor the performance of our services.</p><!-- COOKIE SUBGROUPS*** -->
+                        <!-- COOKIE SUBGROUPS END*** --></div>
+                </div>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="t00"><input type="checkbox"
+                                                                                                name="storage-access"
+                                                                                                id="ot-group-id-t00-toggle"
+                                                                                                aria-expanded="false"
+                                                                                                ot-accordion="true"
+                                                                                                role="button"
+                                                                                                aria-controls="ot-desc-id-t00"
+                                                                                                aria-labelledby="ot-header-id-t00">
+                    <!-- Accordion header -->
+                    <div class="accordion-header"><h4 class="category-header" id="ot-header-id-t00"> First Party
+                        Targeting Cookies</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-switch ot-toggle"><input type="checkbox" name="ot-group-id-t00"
+                                                                class="switch-checkbox category-switch-handler"
+                                                                id="ot-group-id-t00" aria-checked="true" role="switch"
+                                                                data-optanongroupid="t00" checked=""
+                                                                aria-labelledby="ot-header-id-t00"> <label
+                                class="ot-switch-label" for="ot-group-id-t00"><span class="ot-switch-inner"></span>
+                            <span class="ot-switch-nob"></span> <span
+                                    class="label-text"> First Party Targeting Cookies</span></label></div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><p
+                            class="ot-accordion-group-pc-container ot-category-desc" id="ot-desc-id-t00">These cookies
+                        may be used to deliver targeted advertisements and to build a profile of your interests. If you
+                        do not allow these cookies you will still experience advertising but it will be less tailored to
+                        you.</p><!-- COOKIE SUBGROUPS*** --><!-- COOKIE SUBGROUPS END*** --></div>
+                </div>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="IABV2_1"><input type="checkbox"
+                                                                                                    name="storage-access"
+                                                                                                    id="ot-group-id-IABV2_1-toggle"
+                                                                                                    aria-expanded="false"
+                                                                                                    ot-accordion="true"
+                                                                                                    role="button"
+                                                                                                    aria-controls="ot-desc-id-IABV2_1"
+                                                                                                    aria-labelledby="ot-header-id-IABV2_1">
+                    <!-- Accordion header -->
+                    <div class="accordion-header"><h4 class="category-header" id="ot-header-id-IABV2_1">Store and/or
+                        access information on a device</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-switch ot-toggle"><input type="checkbox" name="ot-group-id-IABV2_1"
+                                                                class="switch-checkbox category-switch-handler"
+                                                                id="ot-group-id-IABV2_1" aria-checked="true"
+                                                                role="switch" data-optanongroupid="IABV2_1" checked=""
+                                                                aria-labelledby="ot-header-id-IABV2_1"> <label
+                                class="ot-switch-label" for="ot-group-id-IABV2_1"><span class="ot-switch-inner"></span>
+                            <span class="ot-switch-nob"></span> <span class="label-text">Store and/or access information on a device</span></label>
+                        </div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><p
+                            class="ot-accordion-group-pc-container ot-category-desc" id="ot-desc-id-IABV2_1">Cookies,
+                        device identifiers, or other information can be stored or accessed on your device for the
+                        purposes presented to you.</p><!-- COOKIE SUBGROUPS*** --><!-- COOKIE SUBGROUPS END*** -->
+                        <div class="cookie-subgroups-container">
+                            <ul class="cookie-subgroups">
+                                <li class="cookie-subgroup" data-optanongroupid="i00"><h5>Info Access &amp; Storage</h5>
+                                    <div class="ot-toggle-group cookie-subgroup-toggle">
+                                        <div class="ot-switch ot-toggle ot-hide-tgl"><input type="checkbox"
+                                                                                            name="switch"
+                                                                                            class="switch-checkbox cookie-subgroup-handler"
+                                                                                            id="ot-sub-group-id-i00"
+                                                                                            aria-checked="false"
+                                                                                            role="switch"
+                                                                                            data-optanongroupid="i00"
+                                                                                            aria-label="Info Access &amp; Storage"
+                                                                                            aria-hidden="true"> <label
+                                                class="ot-switch-label" for="ot-sub-group-id-i00"><span
+                                                class="ot-switch-inner"></span> <span class="ot-switch-nob"></span>
+                                            <span class="label-text">Required Cookies</span></label></div>
+                                    </div>
+                                    <p class="cookie-subgroups-description-legal">.</p></li>
+                            </ul>
+                        </div>
+                        <div class="category-vendors-list-container">
+                            <button class="ot-link-btn category-vendors-list-btn category-vendors-list-handler"
+                                    aria-label="List of IAB Vendors button opens Vendor Details window"
+                                    data-parent-id="IABV2_1">List of IAB Vendors‎
+                            </button>
+                            <a href="https://tcf.cookiepedia.co.uk?lang=en" rel="noopener" target="_blank">&nbsp;|&nbsp;View
+                                Full Legal Text&nbsp;<span class="ot-scrn-rdr">Opens in a new Tab</span></a></div>
+                    </div>
+                </div>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="STACK3"><input type="checkbox"
+                                                                                                   name="storage-access"
+                                                                                                   id="ot-group-id-STACK3-toggle"
+                                                                                                   aria-expanded="false"
+                                                                                                   ot-accordion="true"
+                                                                                                   role="button"
+                                                                                                   aria-controls="ot-desc-id-STACK3"
+                                                                                                   aria-labelledby="ot-header-id-STACK3">
+                    <!-- Accordion header -->
+                    <div class="accordion-header"><h4 class="category-header" id="ot-header-id-STACK3">Personalised
+                        ads</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-switch ot-toggle"><input type="checkbox" name="ot-group-id-STACK3"
+                                                                class="switch-checkbox category-switch-handler"
+                                                                id="ot-group-id-STACK3" aria-checked="true"
+                                                                role="switch" data-optanongroupid="STACK3" checked=""
+                                                                aria-labelledby="ot-header-id-STACK3"> <label
+                                class="ot-switch-label" for="ot-group-id-STACK3"><span class="ot-switch-inner"></span>
+                            <span class="ot-switch-nob"></span> <span class="label-text">Personalised ads</span></label>
+                        </div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><!-- COOKIE SUBGROUPS*** -->
+                        <!-- COOKIE SUBGROUPS END*** -->
+                        <div class="cookie-subgroups-container">
+                            <ul class="cookie-subgroups">
+                                <li class="cookie-subgroup" data-optanongroupid="IABV2_4"><h5>Select personalised
+                                    ads</h5>
+                                    <div class="ot-toggle-group cookie-subgroup-toggle">
+                                        <div class="ot-switch ot-toggle"><input type="checkbox" name="switch"
+                                                                                class="switch-checkbox cookie-subgroup-handler"
+                                                                                id="ot-sub-group-id-IABV2_4"
+                                                                                aria-checked="false" role="switch"
+                                                                                data-optanongroupid="IABV2_4"
+                                                                                aria-label="Select personalised ads"
+                                                                                checked=""> <label
+                                                class="ot-switch-label" for="ot-sub-group-id-IABV2_4"><span
+                                                class="ot-switch-inner"></span> <span class="ot-switch-nob"></span>
+                                            <span class="label-text">Required Cookies</span></label></div>
+                                    </div>
+                                    <p class="cookie-subgroups-description-legal">Personalised ads can be shown to you
+                                        based on a profile about you.</p></li>
+                            </ul>
+                        </div>
+                        <div class="cookie-subgroups-container">
+                            <ul class="cookie-subgroups">
+                                <li class="cookie-subgroup" data-optanongroupid="IABV2_3"><h5>Create a personalised ads
+                                    profile</h5>
+                                    <div class="ot-toggle-group cookie-subgroup-toggle">
+                                        <div class="ot-switch ot-toggle"><input type="checkbox" name="switch"
+                                                                                class="switch-checkbox cookie-subgroup-handler"
+                                                                                id="ot-sub-group-id-IABV2_3"
+                                                                                aria-checked="false" role="switch"
+                                                                                data-optanongroupid="IABV2_3"
+                                                                                aria-label="Create a personalised ads profile"
+                                                                                checked=""> <label
+                                                class="ot-switch-label" for="ot-sub-group-id-IABV2_3"><span
+                                                class="ot-switch-inner"></span> <span class="ot-switch-nob"></span>
+                                            <span class="label-text">Required Cookies</span></label></div>
+                                    </div>
+                                    <p class="cookie-subgroups-description-legal">A profile can be built about you and
+                                        your interests to show you personalised ads that are relevant to you.</p></li>
+                            </ul>
+                        </div>
+                        <div class="cookie-subgroups-container">
+                            <ul class="cookie-subgroups">
+                                <li class="cookie-subgroup" data-optanongroupid="IABV2_2"><h5>Select basic ads</h5>
+                                    <div class="ot-toggle-group cookie-subgroup-toggle">
+                                        <div class="ot-switch ot-toggle"><input type="checkbox" name="switch"
+                                                                                class="switch-checkbox cookie-subgroup-handler"
+                                                                                id="ot-sub-group-id-IABV2_2"
+                                                                                aria-checked="false" role="switch"
+                                                                                data-optanongroupid="IABV2_2"
+                                                                                aria-label="Select basic ads"
+                                                                                checked=""> <label
+                                                class="ot-switch-label" for="ot-sub-group-id-IABV2_2"><span
+                                                class="ot-switch-inner"></span> <span class="ot-switch-nob"></span>
+                                            <span class="label-text">Required Cookies</span></label></div>
+                                    </div>
+                                    <p class="cookie-subgroups-description-legal">Ads can be shown to you based on the
+                                        content you’re viewing, the app you’re using, your approximate location, or your
+                                        device type.</p></li>
+                            </ul>
+                        </div>
+                        <div class="category-vendors-list-container">
+                            <button class="ot-link-btn category-vendors-list-btn category-vendors-list-handler"
+                                    aria-label="List of IAB Vendors button opens Vendor Details window"
+                                    data-parent-id="STACK3">List of IAB Vendors‎
+                            </button>
+                            <a href="https://tcf.cookiepedia.co.uk?lang=en" rel="noopener" target="_blank">&nbsp;|&nbsp;View
+                                Full Legal Text&nbsp;<span class="ot-scrn-rdr">Opens in a new Tab</span></a></div>
+                    </div>
+                </div>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="STACK11"><input type="checkbox"
+                                                                                                    name="storage-access"
+                                                                                                    id="ot-group-id-STACK11-toggle"
+                                                                                                    aria-expanded="false"
+                                                                                                    ot-accordion="true"
+                                                                                                    role="button"
+                                                                                                    aria-controls="ot-desc-id-STACK11"
+                                                                                                    aria-labelledby="ot-header-id-STACK11">
+                    <!-- Accordion header -->
+                    <div class="accordion-header"><h4 class="category-header" id="ot-header-id-STACK11">Personalised
+                        content</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-switch ot-toggle"><input type="checkbox" name="ot-group-id-STACK11"
+                                                                class="switch-checkbox category-switch-handler"
+                                                                id="ot-group-id-STACK11" aria-checked="true"
+                                                                role="switch" data-optanongroupid="STACK11" checked=""
+                                                                aria-labelledby="ot-header-id-STACK11"> <label
+                                class="ot-switch-label" for="ot-group-id-STACK11"><span class="ot-switch-inner"></span>
+                            <span class="ot-switch-nob"></span> <span
+                                    class="label-text">Personalised content</span></label></div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><!-- COOKIE SUBGROUPS*** -->
+                        <!-- COOKIE SUBGROUPS END*** -->
+                        <div class="cookie-subgroups-container">
+                            <ul class="cookie-subgroups">
+                                <li class="cookie-subgroup" data-optanongroupid="IABV2_5"><h5>Create a personalised
+                                    content profile</h5>
+                                    <div class="ot-toggle-group cookie-subgroup-toggle">
+                                        <div class="ot-switch ot-toggle"><input type="checkbox" name="switch"
+                                                                                class="switch-checkbox cookie-subgroup-handler"
+                                                                                id="ot-sub-group-id-IABV2_5"
+                                                                                aria-checked="false" role="switch"
+                                                                                data-optanongroupid="IABV2_5"
+                                                                                aria-label="Create a personalised content profile"
+                                                                                checked=""> <label
+                                                class="ot-switch-label" for="ot-sub-group-id-IABV2_5"><span
+                                                class="ot-switch-inner"></span> <span class="ot-switch-nob"></span>
+                                            <span class="label-text">Required Cookies</span></label></div>
+                                    </div>
+                                    <p class="cookie-subgroups-description-legal">A profile can be built about you and
+                                        your interests to show you personalised content that is relevant to you.</p>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="cookie-subgroups-container">
+                            <ul class="cookie-subgroups">
+                                <li class="cookie-subgroup" data-optanongroupid="IABV2_6"><h5>Select personalised
+                                    content</h5>
+                                    <div class="ot-toggle-group cookie-subgroup-toggle">
+                                        <div class="ot-switch ot-toggle"><input type="checkbox" name="switch"
+                                                                                class="switch-checkbox cookie-subgroup-handler"
+                                                                                id="ot-sub-group-id-IABV2_6"
+                                                                                aria-checked="false" role="switch"
+                                                                                data-optanongroupid="IABV2_6"
+                                                                                aria-label="Select personalised content"
+                                                                                checked=""> <label
+                                                class="ot-switch-label" for="ot-sub-group-id-IABV2_6"><span
+                                                class="ot-switch-inner"></span> <span class="ot-switch-nob"></span>
+                                            <span class="label-text">Required Cookies</span></label></div>
+                                    </div>
+                                    <p class="cookie-subgroups-description-legal">Personalised content can be shown to
+                                        you based on a profile about you.</p></li>
+                            </ul>
+                        </div>
+                        <div class="category-vendors-list-container">
+                            <button class="ot-link-btn category-vendors-list-btn category-vendors-list-handler"
+                                    aria-label="List of IAB Vendors button opens Vendor Details window"
+                                    data-parent-id="STACK11">List of IAB Vendors‎
+                            </button>
+                            <a href="https://tcf.cookiepedia.co.uk?lang=en" rel="noopener" target="_blank">&nbsp;|&nbsp;View
+                                Full Legal Text&nbsp;<span class="ot-scrn-rdr">Opens in a new Tab</span></a></div>
+                    </div>
+                </div>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="STACK20"><input type="checkbox"
+                                                                                                    name="storage-access"
+                                                                                                    id="ot-group-id-STACK20-toggle"
+                                                                                                    aria-expanded="false"
+                                                                                                    ot-accordion="true"
+                                                                                                    role="button"
+                                                                                                    aria-controls="ot-desc-id-STACK20"
+                                                                                                    aria-labelledby="ot-header-id-STACK20">
+                    <!-- Accordion header -->
+                    <div class="accordion-header"><h4 class="category-header" id="ot-header-id-STACK20">Ad and content
+                        measurement, audience insights, and product development</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-switch ot-toggle"><input type="checkbox" name="ot-group-id-STACK20"
+                                                                class="switch-checkbox category-switch-handler"
+                                                                id="ot-group-id-STACK20" aria-checked="true"
+                                                                role="switch" data-optanongroupid="STACK20" checked=""
+                                                                aria-labelledby="ot-header-id-STACK20"> <label
+                                class="ot-switch-label" for="ot-group-id-STACK20"><span class="ot-switch-inner"></span>
+                            <span class="ot-switch-nob"></span> <span class="label-text">Ad and content measurement, audience insights, and product development</span></label>
+                        </div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><!-- COOKIE SUBGROUPS*** -->
+                        <!-- COOKIE SUBGROUPS END*** -->
+                        <div class="cookie-subgroups-container">
+                            <ul class="cookie-subgroups">
+                                <li class="cookie-subgroup" data-optanongroupid="IABV2_9"><h5>Apply market research to
+                                    generate audience insights</h5>
+                                    <div class="ot-toggle-group cookie-subgroup-toggle">
+                                        <div class="ot-switch ot-toggle"><input type="checkbox" name="switch"
+                                                                                class="switch-checkbox cookie-subgroup-handler"
+                                                                                id="ot-sub-group-id-IABV2_9"
+                                                                                aria-checked="false" role="switch"
+                                                                                data-optanongroupid="IABV2_9"
+                                                                                aria-label="Apply market research to generate audience insights"
+                                                                                checked=""> <label
+                                                class="ot-switch-label" for="ot-sub-group-id-IABV2_9"><span
+                                                class="ot-switch-inner"></span> <span class="ot-switch-nob"></span>
+                                            <span class="label-text">Required Cookies</span></label></div>
+                                    </div>
+                                    <p class="cookie-subgroups-description-legal">Market research can be used to learn
+                                        more about the audiences who visit sites/apps and view ads.</p></li>
+                            </ul>
+                        </div>
+                        <div class="cookie-subgroups-container">
+                            <ul class="cookie-subgroups">
+                                <li class="cookie-subgroup" data-optanongroupid="IABV2_10"><h5>Develop and improve
+                                    products</h5>
+                                    <div class="ot-toggle-group cookie-subgroup-toggle">
+                                        <div class="ot-switch ot-toggle"><input type="checkbox" name="switch"
+                                                                                class="switch-checkbox cookie-subgroup-handler"
+                                                                                id="ot-sub-group-id-IABV2_10"
+                                                                                aria-checked="false" role="switch"
+                                                                                data-optanongroupid="IABV2_10"
+                                                                                aria-label="Develop and improve products"
+                                                                                checked=""> <label
+                                                class="ot-switch-label" for="ot-sub-group-id-IABV2_10"><span
+                                                class="ot-switch-inner"></span> <span class="ot-switch-nob"></span>
+                                            <span class="label-text">Required Cookies</span></label></div>
+                                    </div>
+                                    <p class="cookie-subgroups-description-legal">Your data can be used to improve
+                                        existing systems and software, and to develop new products</p></li>
+                            </ul>
+                        </div>
+                        <div class="cookie-subgroups-container">
+                            <ul class="cookie-subgroups">
+                                <li class="cookie-subgroup" data-optanongroupid="IABV2_8"><h5>Measure content
+                                    performance</h5>
+                                    <div class="ot-toggle-group cookie-subgroup-toggle">
+                                        <div class="ot-switch ot-toggle"><input type="checkbox" name="switch"
+                                                                                class="switch-checkbox cookie-subgroup-handler"
+                                                                                id="ot-sub-group-id-IABV2_8"
+                                                                                aria-checked="false" role="switch"
+                                                                                data-optanongroupid="IABV2_8"
+                                                                                aria-label="Measure content performance"
+                                                                                checked=""> <label
+                                                class="ot-switch-label" for="ot-sub-group-id-IABV2_8"><span
+                                                class="ot-switch-inner"></span> <span class="ot-switch-nob"></span>
+                                            <span class="label-text">Required Cookies</span></label></div>
+                                    </div>
+                                    <p class="cookie-subgroups-description-legal">The performance and effectiveness of
+                                        content that you see or interact with can be measured.</p></li>
+                            </ul>
+                        </div>
+                        <div class="cookie-subgroups-container">
+                            <ul class="cookie-subgroups">
+                                <li class="cookie-subgroup" data-optanongroupid="IABV2_7"><h5>Measure ad
+                                    performance</h5>
+                                    <div class="ot-toggle-group cookie-subgroup-toggle">
+                                        <div class="ot-switch ot-toggle"><input type="checkbox" name="switch"
+                                                                                class="switch-checkbox cookie-subgroup-handler"
+                                                                                id="ot-sub-group-id-IABV2_7"
+                                                                                aria-checked="false" role="switch"
+                                                                                data-optanongroupid="IABV2_7"
+                                                                                aria-label="Measure ad performance"
+                                                                                checked=""> <label
+                                                class="ot-switch-label" for="ot-sub-group-id-IABV2_7"><span
+                                                class="ot-switch-inner"></span> <span class="ot-switch-nob"></span>
+                                            <span class="label-text">Required Cookies</span></label></div>
+                                    </div>
+                                    <p class="cookie-subgroups-description-legal">The performance and effectiveness of
+                                        ads that you see or interact with can be measured.</p></li>
+                            </ul>
+                        </div>
+                        <div class="category-vendors-list-container">
+                            <button class="ot-link-btn category-vendors-list-btn category-vendors-list-handler"
+                                    aria-label="List of IAB Vendors button opens Vendor Details window"
+                                    data-parent-id="STACK20">List of IAB Vendors‎
+                            </button>
+                            <a href="https://tcf.cookiepedia.co.uk?lang=en" rel="noopener" target="_blank">&nbsp;|&nbsp;View
+                                Full Legal Text&nbsp;<span class="ot-scrn-rdr">Opens in a new Tab</span></a></div>
+                    </div>
+                </div>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="ISPV2_1"><input type="checkbox"
+                                                                                                    name="storage-access"
+                                                                                                    id="ot-group-id-ISPV2_1-toggle"
+                                                                                                    aria-expanded="false"
+                                                                                                    ot-accordion="true"
+                                                                                                    role="button"
+                                                                                                    aria-controls="ot-desc-id-ISPV2_1"
+                                                                                                    aria-labelledby="ot-header-id-ISPV2_1">
+                    <!-- Accordion header -->
+                    <div class="accordion-header ot-always-active-group"><h4 class="category-header"
+                                                                             id="ot-header-id-ISPV2_1">Ensure security,
+                        prevent fraud, and debug</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-always-active">Always Active</div>
+                        <div class="ot-switch ot-toggle ot-hide-tgl"><input type="checkbox" name="ot-group-id-ISPV2_1"
+                                                                            class="switch-checkbox category-switch-handler"
+                                                                            id="ot-group-id-ISPV2_1"
+                                                                            aria-checked="false" role="switch"
+                                                                            aria-hidden="true"
+                                                                            data-optanongroupid="ISPV2_1"
+                                                                            aria-labelledby="ot-header-id-ISPV2_1">
+                            <label class="ot-switch-label" for="ot-group-id-ISPV2_1"><span
+                                    class="ot-switch-inner"></span> <span class="ot-switch-nob"></span> <span
+                                    class="label-text">Ensure security, prevent fraud, and debug</span></label></div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><p
+                            class="ot-accordion-group-pc-container ot-category-desc" id="ot-desc-id-ISPV2_1">Your data
+                        can be used to monitor for and prevent fraudulent activity, and ensure systems and processes
+                        work properly and securely.</p><!-- COOKIE SUBGROUPS*** --><!-- COOKIE SUBGROUPS END*** -->
+                        <div class="category-vendors-list-container">
+                            <button class="ot-link-btn category-vendors-list-btn category-vendors-list-handler"
+                                    aria-label="List of IAB Vendors button opens Vendor Details window"
+                                    data-parent-id="ISPV2_1">List of IAB Vendors‎
+                            </button>
+                            <a href="https://tcf.cookiepedia.co.uk?lang=en" rel="noopener" target="_blank">&nbsp;|&nbsp;View
+                                Full Legal Text&nbsp;<span class="ot-scrn-rdr">Opens in a new Tab</span></a></div>
+                    </div>
+                </div>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="ISPV2_2"><input type="checkbox"
+                                                                                                    name="storage-access"
+                                                                                                    id="ot-group-id-ISPV2_2-toggle"
+                                                                                                    aria-expanded="false"
+                                                                                                    ot-accordion="true"
+                                                                                                    role="button"
+                                                                                                    aria-controls="ot-desc-id-ISPV2_2"
+                                                                                                    aria-labelledby="ot-header-id-ISPV2_2">
+                    <!-- Accordion header -->
+                    <div class="accordion-header ot-always-active-group"><h4 class="category-header"
+                                                                             id="ot-header-id-ISPV2_2">Technically
+                        deliver ads or content</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-always-active">Always Active</div>
+                        <div class="ot-switch ot-toggle ot-hide-tgl"><input type="checkbox" name="ot-group-id-ISPV2_2"
+                                                                            class="switch-checkbox category-switch-handler"
+                                                                            id="ot-group-id-ISPV2_2"
+                                                                            aria-checked="false" role="switch"
+                                                                            aria-hidden="true"
+                                                                            data-optanongroupid="ISPV2_2"
+                                                                            aria-labelledby="ot-header-id-ISPV2_2">
+                            <label class="ot-switch-label" for="ot-group-id-ISPV2_2"><span
+                                    class="ot-switch-inner"></span> <span class="ot-switch-nob"></span> <span
+                                    class="label-text">Technically deliver ads or content</span></label></div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><p
+                            class="ot-accordion-group-pc-container ot-category-desc" id="ot-desc-id-ISPV2_2">Your device
+                        can receive and send information that allows you to see and interact with ads and content.</p>
+                        <!-- COOKIE SUBGROUPS*** --><!-- COOKIE SUBGROUPS END*** -->
+                        <div class="category-vendors-list-container">
+                            <button class="ot-link-btn category-vendors-list-btn category-vendors-list-handler"
+                                    aria-label="List of IAB Vendors button opens Vendor Details window"
+                                    data-parent-id="ISPV2_2">List of IAB Vendors‎
+                            </button>
+                            <a href="https://tcf.cookiepedia.co.uk?lang=en" rel="noopener" target="_blank">&nbsp;|&nbsp;View
+                                Full Legal Text&nbsp;<span class="ot-scrn-rdr">Opens in a new Tab</span></a></div>
+                    </div>
+                </div>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="IFEV2_1"><input type="checkbox"
+                                                                                                    name="storage-access"
+                                                                                                    id="ot-group-id-IFEV2_1-toggle"
+                                                                                                    aria-expanded="false"
+                                                                                                    ot-accordion="true"
+                                                                                                    role="button"
+                                                                                                    aria-controls="ot-desc-id-IFEV2_1"
+                                                                                                    aria-labelledby="ot-header-id-IFEV2_1">
+                    <!-- Accordion header -->
+                    <div class="accordion-header ot-always-active-group"><h4 class="category-header"
+                                                                             id="ot-header-id-IFEV2_1">Match and combine
+                        offline data sources</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-always-active">Always Active</div>
+                        <div class="ot-switch ot-toggle ot-hide-tgl"><input type="checkbox" name="ot-group-id-IFEV2_1"
+                                                                            class="switch-checkbox category-switch-handler"
+                                                                            id="ot-group-id-IFEV2_1"
+                                                                            aria-checked="false" role="switch"
+                                                                            aria-hidden="true"
+                                                                            data-optanongroupid="IFEV2_1"
+                                                                            aria-labelledby="ot-header-id-IFEV2_1">
+                            <label class="ot-switch-label" for="ot-group-id-IFEV2_1"><span
+                                    class="ot-switch-inner"></span> <span class="ot-switch-nob"></span> <span
+                                    class="label-text">Match and combine offline data sources</span></label></div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><p
+                            class="ot-accordion-group-pc-container ot-category-desc" id="ot-desc-id-IFEV2_1">Data from
+                        offline data sources can be combined with your online activity in support of one or more
+                        purposes</p><!-- COOKIE SUBGROUPS*** --><!-- COOKIE SUBGROUPS END*** -->
+                        <div class="category-vendors-list-container">
+                            <button class="ot-link-btn category-vendors-list-btn category-vendors-list-handler"
+                                    aria-label="List of IAB Vendors button opens Vendor Details window"
+                                    data-parent-id="IFEV2_1">List of IAB Vendors‎
+                            </button>
+                            <a href="https://tcf.cookiepedia.co.uk?lang=en" rel="noopener" target="_blank">&nbsp;|&nbsp;View
+                                Full Legal Text&nbsp;<span class="ot-scrn-rdr">Opens in a new Tab</span></a></div>
+                    </div>
+                </div>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="IFEV2_2"><input type="checkbox"
+                                                                                                    name="storage-access"
+                                                                                                    id="ot-group-id-IFEV2_2-toggle"
+                                                                                                    aria-expanded="false"
+                                                                                                    ot-accordion="true"
+                                                                                                    role="button"
+                                                                                                    aria-controls="ot-desc-id-IFEV2_2"
+                                                                                                    aria-labelledby="ot-header-id-IFEV2_2">
+                    <!-- Accordion header -->
+                    <div class="accordion-header ot-always-active-group"><h4 class="category-header"
+                                                                             id="ot-header-id-IFEV2_2">Link different
+                        devices</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-always-active">Always Active</div>
+                        <div class="ot-switch ot-toggle ot-hide-tgl"><input type="checkbox" name="ot-group-id-IFEV2_2"
+                                                                            class="switch-checkbox category-switch-handler"
+                                                                            id="ot-group-id-IFEV2_2"
+                                                                            aria-checked="false" role="switch"
+                                                                            aria-hidden="true"
+                                                                            data-optanongroupid="IFEV2_2"
+                                                                            aria-labelledby="ot-header-id-IFEV2_2">
+                            <label class="ot-switch-label" for="ot-group-id-IFEV2_2"><span
+                                    class="ot-switch-inner"></span> <span class="ot-switch-nob"></span> <span
+                                    class="label-text">Link different devices</span></label></div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><p
+                            class="ot-accordion-group-pc-container ot-category-desc" id="ot-desc-id-IFEV2_2">Different
+                        devices can be determined as belonging to you or your household in support of one or more of
+                        purposes.</p><!-- COOKIE SUBGROUPS*** --><!-- COOKIE SUBGROUPS END*** -->
+                        <div class="category-vendors-list-container">
+                            <button class="ot-link-btn category-vendors-list-btn category-vendors-list-handler"
+                                    aria-label="List of IAB Vendors button opens Vendor Details window"
+                                    data-parent-id="IFEV2_2">List of IAB Vendors‎
+                            </button>
+                            <a href="https://tcf.cookiepedia.co.uk?lang=en" rel="noopener" target="_blank">&nbsp;|&nbsp;View
+                                Full Legal Text&nbsp;<span class="ot-scrn-rdr">Opens in a new Tab</span></a></div>
+                    </div>
+                </div>
+                <div class="ot-accordion-layout category-item" data-optanongroupid="IFEV2_3"><input type="checkbox"
+                                                                                                    name="storage-access"
+                                                                                                    id="ot-group-id-IFEV2_3-toggle"
+                                                                                                    aria-expanded="false"
+                                                                                                    ot-accordion="true"
+                                                                                                    role="button"
+                                                                                                    aria-controls="ot-desc-id-IFEV2_3"
+                                                                                                    aria-labelledby="ot-header-id-IFEV2_3">
+                    <!-- Accordion header -->
+                    <div class="accordion-header ot-always-active-group"><h4 class="category-header"
+                                                                             id="ot-header-id-IFEV2_3">Receive and use
+                        automatically-sent device characteristics for identification</h4><!-- Group toggle -->
+                        <div class="ot-arrow-container">
+                            <svg class="ot-arrow" width="15px" height="15px" aria-hidden="true" focusable="false"
+                                 data-prefix="fas" data-icon="caret-right" role="img" xmlns="http://www.w3.org/2000/svg"
+                                 viewBox="0 0 192 512">
+                                <path fill="currentColor"
+                                      d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"></path>
+                            </svg>
+                        </div>
+                        <div class="ot-always-active">Always Active</div>
+                        <div class="ot-switch ot-toggle ot-hide-tgl"><input type="checkbox" name="ot-group-id-IFEV2_3"
+                                                                            class="switch-checkbox category-switch-handler"
+                                                                            id="ot-group-id-IFEV2_3"
+                                                                            aria-checked="false" role="switch"
+                                                                            aria-hidden="true"
+                                                                            data-optanongroupid="IFEV2_3"
+                                                                            aria-labelledby="ot-header-id-IFEV2_3">
+                            <label class="ot-switch-label" for="ot-group-id-IFEV2_3"><span
+                                    class="ot-switch-inner"></span> <span class="ot-switch-nob"></span> <span
+                                    class="label-text">Receive and use automatically-sent device characteristics for identification</span></label>
+                        </div>
+                    </div><!-- accordion detail -->
+                    <div class="ot-accordion-pc-container accordion-text"><p
+                            class="ot-accordion-group-pc-container ot-category-desc" id="ot-desc-id-IFEV2_3">Your device
+                        might be distinguished from other devices based on information it automatically sends, such as
+                        IP address or browser type.</p><!-- COOKIE SUBGROUPS*** --><!-- COOKIE SUBGROUPS END*** -->
+                        <div class="category-vendors-list-container">
+                            <button class="ot-link-btn category-vendors-list-btn category-vendors-list-handler"
+                                    aria-label="List of IAB Vendors button opens Vendor Details window"
+                                    data-parent-id="IFEV2_3">List of IAB Vendors‎
+                            </button>
+                            <a href="https://tcf.cookiepedia.co.uk?lang=en" rel="noopener" target="_blank">&nbsp;|&nbsp;View
+                                Full Legal Text&nbsp;<span class="ot-scrn-rdr">Opens in a new Tab</span></a></div>
+                    </div>
+                </div><!-- Groups sections starts --><!-- Group section ends --><!-- Accordion Group section starts -->
+                <!-- Accordion Group section ends --><!-- Footer section starts -->
+                <div class="save-preference-btn-container">
+                    <button class="save-preference-btn-handler onetrust-close-btn-handler button-theme">Confirm My
+                        Choices
+                    </button>
+                    <div class="ot-pc-footer-logo"><a class="powered-by-logo"
+                                                      href="https://www.onetrust.com/products/cookie-consent/"
+                                                      target="_blank" rel="noopener noreferrer"
+                                                      style="background-image: url(&quot;https://cdn.cookielaw.org/logos/static/poweredBy_ot_logo.svg&quot;);"
+                                                      aria-label="Powered by OneTrust Opens in a new Tab"></a></div>
+                </div><!-- Footer section ends --></section>
+        </div>
+        <section id="vendors-list" class="ot-hide hosts-list">
+            <div id="vendors-list-header">
+                <button class="ot-link-btn back-btn-handler" aria-label="Back">
+                    <svg id="ot-back-arrow" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 444.531 444.531" xml:space="preserve"><title>Back Button</title><g><path fill="#656565" d="M213.13,222.409L351.88,83.653c7.05-7.043,10.567-15.657,10.567-25.841c0-10.183-3.518-18.793-10.567-25.835
+                      l-21.409-21.416C323.432,3.521,314.817,0,304.637,0s-18.791,3.521-25.841,10.561L92.649,196.425
+                      c-7.044,7.043-10.566,15.656-10.566,25.841s3.521,18.791,10.566,25.837l186.146,185.864c7.05,7.043,15.66,10.564,25.841,10.564
+                      s18.795-3.521,25.834-10.564l21.409-21.412c7.05-7.039,10.567-15.604,10.567-25.697c0-10.085-3.518-18.746-10.567-25.978
+                      L213.13,222.409z"></path></g></svg>
+                    <p class="pc-back-button-text">Back</p></button><!-- Close Button -->
+                <button id="vendor-close-pc-btn-handler" class="vendors-list pc-close-button ot-close-icon"
+                        aria-label="Close"></button><!-- Close Button --><h3 id="vendors-list-title">Performance
+                Cookies</h3>
+                <div id="search-container"><p role="status" class="screen-reader-only"></p><label
+                        for="vendor-search-handler" class="screen-reader-only">Vendor Search</label> <input
+                        id="vendor-search-handler" type="text" placeholder="Search..." name="vendor-search-handler">
+                    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+                         width="30" height="30" viewBox="0 -30 110 110" aria-hidden="true"><title>Search Icon</title>
+                        <path fill="#2e3644" d="M55.146,51.887L41.588,37.786c3.486-4.144,5.396-9.358,5.396-14.786c0-12.682-10.318-23-23-23s-23,10.318-23,23
+                  s10.318,23,23,23c4.761,0,9.298-1.436,13.177-4.162l13.661,14.208c0.571,0.593,1.339,0.92,2.162,0.92
+                  c0.779,0,1.518-0.297,2.079-0.837C56.255,54.982,56.293,53.08,55.146,51.887z M23.984,6c9.374,0,17,7.626,17,17s-7.626,17-17,17
+                  s-17-7.626-17-17S14.61,6,23.984,6z"></path>
+                    </svg>
+                    <button class="ot-link-btn" id="filter-btn-handler" aria-label="Filter Icon" aria-haspopup="true">
+                        <svg role="presentation" aria-hidden="true" id="filter-icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="15px" height="15px" viewBox="0 0 402.577 402.577" xml:space="preserve"><title>Filter Icon</title><g><path id="filter-icon-path" fill="#656565" d="M400.858,11.427c-3.241-7.421-8.85-11.132-16.854-11.136H18.564c-7.993,0-13.61,3.715-16.846,11.136
+                c-3.234,7.801-1.903,14.467,3.999,19.985l140.757,140.753v138.755c0,4.955,1.809,9.232,5.424,12.854l73.085,73.083
+                c3.429,3.614,7.71,5.428,12.851,5.428c2.282,0,4.66-0.479,7.135-1.43c7.426-3.238,11.14-8.851,11.14-16.845V172.166L396.861,31.413
+                C402.765,25.895,404.093,19.231,400.858,11.427z"></path></g></svg>
+                    </button>
+                    <div id="ot-triangle"></div>
+                    <section id="ot-filter-modal">
+                        <div id="ot-options">
+                            <div id="clear-filters-container">
+                                <button class="ot-link-btn" id="clear-filters-handler"><p>Clear Filters</p></button>
+                            </div>
+                            <div class="ot-group-options">
+                                <div class="ot-group-option">
+                                    <div class="ot-checkbox"><input id="storage-access-group"
+                                                                    class="ot-group-option-box category-filter-handler"
+                                                                    type="checkbox"> <label
+                                            for="storage-access-group"><span>Information storage and access</span></label>
+                                    </div>
+                                </div>
+                            </div>
+                            <button id="filter-apply-handler" class="ot-pill">Apply</button>
+                        </div>
+                    </section>
+                </div>
+                <div id="select-all-container">
+                    <div class="ot-checkbox">
+                        <div class="leg-int-sel-all-hdr"><span class="consent-hdr">Consent</span> <span
+                                class="leg-int-hdr">Leg.Interest</span></div>
+                        <div id="select-all-text-container"><p>All Consent Allowed</p></div>
+                        <!-- select all vendor leg.int toggle container -->
+                        <div id="select-all-vendors-leg-input-container"><input id="select-all-vendor-leg-handler"
+                                                                                class="ot-group-option-box"
+                                                                                type="checkbox"> <label
+                                for="select-all-vendor-leg-handler"><span
+                                class="label-text">Select All Vendors</span></label></div>
+                        <!-- select all vendor consent toggle container -->
+                        <div id="select-all-vendors-input-container"><input id="select-all-vendor-groups-handler"
+                                                                            class="ot-group-option-box" type="checkbox">
+                            <label for="select-all-vendor-groups-handler"><span
+                                    class="label-text">Select All Vendors</span></label></div>
+                        <!-- Hosts select all input container -->
+                        <div id="select-all-hosts-input-container"><input id="select-all-hosts-groups-handler"
+                                                                          class="ot-group-option-box" type="checkbox">
+                            <label for="select-all-hosts-groups-handler"><span
+                                    class="label-text">All Consent Allowed</span></label></div>
+                    </div>
+                </div>
+            </div>
+            <section id="vendor-list-content" class="host-list-content">
+                <div id="vendors-list-text" class="ot-sdk-row">
+                    <div class="ot-sdk-column">
+                        <ul id="vendors-list-container"></ul>
+                    </div>
+                </div>
+            </section>
+            <div id="vendor-list-save-btn" class="save-preference-btn-container">
+                <button class="save-preference-btn-handler onetrust-close-btn-handler button-theme">Confirm My Choices
+                </button>
+                <div class="ot-pc-footer-logo"><a class="powered-by-logo"
+                                                  href="https://www.onetrust.com/products/cookie-consent/"
+                                                  target="_blank" rel="noopener noreferrer"
+                                                  style="background-image: url(&quot;https://cdn.cookielaw.org/logos/static/poweredBy_ot_logo.svg&quot;);"
+                                                  aria-label="Powered by OneTrust Opens in a new Tab"></a></div>
+            </div>
+        </section>
+        <iframe class="ot-text-resize" title="onetrust-text-resize"
+                style="position: absolute; top: -50000px; width: 100em;" aria-hidden="true"></iframe>
+    </div>
+</div>
+</body>
+<style>
+    img.mwe-math-fallback-image-inline {
+        filter: invert(100%);
+    }</style>
+</html>

--- a/tests/fixtures/example_output.json
+++ b/tests/fixtures/example_output.json
@@ -1,0 +1,81 @@
+{
+  "artists": {
+    "href": "https://api.spotify.com/v1/search?query=LIVL%C3%98S&type=artist&offset=0&limit=20",
+    "items": [
+      {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/artist/3upLnjEfkXlcb8IddTLQUA"
+        },
+        "followers": {
+          "href": "None",
+          "total": 2816
+        },
+        "genres": [
+          "danish death metal",
+          "danish metal"
+        ],
+        "href": "https://api.spotify.com/v1/artists/3upLnjEfkXlcb8IddTLQUA",
+        "id": "3upLnjEfkXlcb8IddTLQUA",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab6761610000e5ebba0eda07c5a1246b4c724977",
+            "width": 640
+          },
+          {
+            "height": 320,
+            "url": "https://i.scdn.co/image/ab67616100005174ba0eda07c5a1246b4c724977",
+            "width": 320
+          },
+          {
+            "height": 160,
+            "url": "https://i.scdn.co/image/ab6761610000f178ba0eda07c5a1246b4c724977",
+            "width": 160
+          }
+        ],
+        "name": "LIVLØS",
+        "popularity": 26,
+        "type": "artist",
+        "uri": "spotify:artist:3upLnjEfkXlcb8IddTLQUA"
+      },
+      {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/artist/6EsU43JcL88IcD1seD8tzl"
+        },
+        "followers": {
+          "href": "None",
+          "total": 368
+        },
+        "genres": [],
+        "href": "https://api.spotify.com/v1/artists/6EsU43JcL88IcD1seD8tzl",
+        "id": "6EsU43JcL88IcD1seD8tzl",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab6761610000e5ebc07cf3be67dd0e6c1c6e48a6",
+            "width": 640
+          },
+          {
+            "height": 320,
+            "url": "https://i.scdn.co/image/ab67616100005174c07cf3be67dd0e6c1c6e48a6",
+            "width": 320
+          },
+          {
+            "height": 160,
+            "url": "https://i.scdn.co/image/ab6761610000f178c07cf3be67dd0e6c1c6e48a6",
+            "width": 160
+          }
+        ],
+        "name": "Livløst",
+        "popularity": 7,
+        "type": "artist",
+        "uri": "spotify:artist:6EsU43JcL88IcD1seD8tzl"
+      }
+    ],
+    "limit": 20,
+    "next": "None",
+    "offset": 0,
+    "previous": "None",
+    "total": 2
+  }
+}

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -83,7 +83,7 @@ class TestRecommendation(SpotirecTestCase):
         Testing playlist_description()
         """
         description = 'Created by Spotirec - ' + self.timestamp + ' - based on top genres - seed: '
-        self.assertEqual(self.rec.playlist_description(), description)
+        self.assertEqual(self.rec.playlist_description(False), description)
 
     @ordered
     def test_update_limit(self):


### PR DESCRIPTION
Depends on #165 
Fixes #164

This addition adds the following to requirements.txt;
setuptools~=58.1.0
beautifulsoup4~=4.10.0

By allowing the user to add the following to their parameters
--concert {URL FOR CONCERT}
It will use the Spotify API's get top songs from artist, and return the 10 top songs from the artist.

example run;
spotirec --concert https://open.spotify.com/concert/0SNQXtkavzC3ohSzJCmb9W

Will create a playlist containing the top 10 songs from the artists performing at Udgårfsfest 2022 2022.
Additionally the naming convention for the playlists have changed such that it contains the name of the concert that the user is creating a playlist over.

Please note that the name of the concert that is used for generating this playlist is called Udgårfsfest 2022 2022 and is not a problem with the naming of the playlist.
![image](https://user-images.githubusercontent.com/15718221/145026866-05104122-d6f9-4672-88df-3b6b5aeee22d.png)
